### PR TITLE
Fixed entity (player) movement and a few typos

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncTask.java
@@ -33,15 +33,15 @@ public abstract class AsyncTask extends BukkitRunnable {
 
     public void run() {
         try {
-            excecute();
+            execute();
             Movecraft.getInstance().getAsyncManager().submitCompletedTask(this);
         } catch (Exception e) {
-            Movecraft.getInstance().getLogger().log(Level.SEVERE, I18nSupport.getInternationalisedString("Internal - Error - Proccessor thread encountered an error"));
+            Movecraft.getInstance().getLogger().log(Level.SEVERE, I18nSupport.getInternationalisedString("Internal - Error - Processor thread encountered an error"));
             e.printStackTrace();
         }
     }
 
-    protected abstract void excecute();
+    protected abstract void execute();
 
     protected Craft getCraft() {
         return craft;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/detection/DetectionTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/detection/DetectionTask.java
@@ -61,7 +61,7 @@ public class DetectionTask extends AsyncTask {
     }
 
     @Override
-    public void excecute() {
+    public void execute() {
         Map<List<Integer>, List<Double>> flyBlocks = getCraft().getType().getFlyBlocks();
         dFlyBlocks = flyBlocks;
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -88,7 +88,7 @@ public class RotationTask extends AsyncTask {
     }
 
     @Override
-    protected void excecute() {
+    protected void execute() {
 
         if(oldHitBox.isEmpty())
             return;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -48,7 +48,7 @@ public class TranslationTask extends AsyncTask {
     }
 
     @Override
-    protected void excecute() {
+    protected void execute() {
 
         //Check if theres anything to move
         if(oldHitBox.isEmpty()){
@@ -211,22 +211,17 @@ public class TranslationTask extends AsyncTask {
 
         //prevents torpedo and rocket pilots
         if (craft.getType().getMoveEntities() && !(craft.getSinking() && craft.getType().getOnlyMovePlayers())) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    for(Entity entity : craft.getW().getNearbyEntities(craft.getHitBox().getMidPoint().toBukkit(craft.getW()), craft.getHitBox().getXLength()/2.0 + 1, craft.getHitBox().getYLength()/2.0 + 1, craft.getHitBox().getZLength()/2.0 + 1)){
-                        if (entity.getType() == EntityType.PLAYER && !craft.getSinking()) {
-                            Player player = (Player) entity;
-                            craft.getMovedPlayers().put(player, System.currentTimeMillis());
-                            EntityUpdateCommand eUp = new EntityUpdateCommand(entity, dx, dy, dz, 0, 0);
-                            updates.add(eUp);
-                        } else if (!craft.getType().getOnlyMovePlayers() || entity.getType() == EntityType.PRIMED_TNT) {
-                            EntityUpdateCommand eUp = new EntityUpdateCommand(entity, dx, dy, dz, 0, 0);
-                            updates.add(eUp);
-                        }
-                    }
+            for (Entity entity : craft.getW().getNearbyEntities(craft.getHitBox().getMidPoint().toBukkit(craft.getW()), craft.getHitBox().getXLength() / 2.0 + 1, craft.getHitBox().getYLength() / 2.0 + 1, craft.getHitBox().getZLength() / 2.0 + 1)) {
+                if (entity.getType() == EntityType.PLAYER && !craft.getSinking()) {
+                    Player player = (Player) entity;
+                    craft.getMovedPlayers().put(player, System.currentTimeMillis());
+                    EntityUpdateCommand eUp = new EntityUpdateCommand(entity, dx, dy, dz, 0, 0);
+                    updates.add(eUp);
+                } else if (!craft.getType().getOnlyMovePlayers() || entity.getType() == EntityType.PRIMED_TNT) {
+                    EntityUpdateCommand eUp = new EntityUpdateCommand(entity, dx, dy, dz, 0, 0);
+                    updates.add(eUp);
                 }
-            }.runTask(Movecraft.getInstance());
+            }
         } else {
             //add releaseTask without playermove to manager
             if (!craft.getType().getCruiseOnPilot() && !craft.getSinking())  // not necessary to release cruiseonpilot crafts, because they will already be released

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RemoteSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RemoteSign.java
@@ -60,7 +60,7 @@ public final class RemoteSign implements Listener{
             event.getPlayer().sendMessage("ERROR: Remote Sign can't remote another Remote Sign!");
             return;
         }
-        LinkedList<MovecraftLocation> foundLocations = new LinkedList<MovecraftLocation>;
+        LinkedList<MovecraftLocation> foundLocations = new LinkedList<MovecraftLocation>();
         for (MovecraftLocation tloc : foundCraft.getHitBox()) {
             Block tb = event.getClickedBlock().getWorld().getBlockAt(tloc.getX(), tloc.getY(), tloc.getZ());
             if (!tb.getType().equals(Material.SIGN_POST) && !tb.getType().equals(Material.WALL_SIGN)) {


### PR DESCRIPTION
Made the translation task not use Bukkit's runTask as it needs to add to updates immediately. The updates are processed right in the following tick, it seems to always happen before the removed task was run.

It works without using runTask, looking at the source code I think the only case it could cause issues is if the chunk(s) the craft is in is unloaded because then getNearbyEntities() will attempt to load it asynchronously. Other than that, the teleportation itself seems to get scheduled to the server thread.
