### PR TITLE
Header of Region Damaged sign has been localised

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RegionDamagedSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RegionDamagedSign.java
@@ -25,7 +25,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import java.util.UUID;
 
 public class RegionDamagedSign implements Listener {
-    private final String HEADER = ChatColor.RED + "REGION DAMAGED!";
+    private final String HEADER = ChatColor.RED + I18nSupport.getInternationalisedString("Region Damaged");
 
     @EventHandler
     public void onSignRightClick(PlayerInteractEvent event){


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
the first line of a Region Damaged sign in RegionDamagedSign class has been localised instead of being hard-coded at REGION DAMAGED!

Minor fix


### Checklist
- [x] Unit tests <!-- if implementing API utilities -->
- [x] Proper internationalization
- [x] Compiled/tested
