### PR TITLE
Nuka-Torp fix

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -315,11 +315,6 @@ public class AsyncManager extends BukkitRunnable {
 
 
                         sentMapUpdate = true;
-
-                        /*c.setBlockList(task.getBlockList());
-                        c.setMinX(task.getMinX());
-                        c.setMinZ(task.getMinZ());
-                        c.setHitBox(task.getHitbox());*/
                         c.setHitBox(task.getNewHitBox());
 
                         // rotate any cannons that were present

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -25,18 +25,16 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
-import net.countercraft.movecraft.craft.Craft;
-import net.countercraft.movecraft.events.CraftRotateEvent;
-import net.countercraft.movecraft.events.CraftTranslateEvent;
-import net.countercraft.movecraft.utils.*;
-import net.countercraft.movecraft.utils.HashHitBox;
 import net.countercraft.movecraft.async.AsyncTask;
 import net.countercraft.movecraft.config.Settings;
+import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
+import net.countercraft.movecraft.events.CraftRotateEvent;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.mapUpdater.update.CraftRotateCommand;
 import net.countercraft.movecraft.mapUpdater.update.EntityUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
+import net.countercraft.movecraft.utils.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -47,10 +45,8 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class RotationTask extends AsyncTask {
@@ -192,6 +188,7 @@ public class RotationTask extends AsyncTask {
                 break;
             }
         }
+
         if (failed) {
             if (this.isSubCraft && parentCraft != getCraft()) {
                 parentCraft.setProcessing(false);
@@ -310,12 +307,20 @@ public class RotationTask extends AsyncTask {
                 if (newHitBox.intersects(craft.getHitBox()) && craft != getCraft()) {
                     //newHitBox.addAll(CollectionUtils.filter(craft.getHitBox(),newHitBox));
                     //craft.setHitBox(newHitBox);
+                    if (Settings.Debug) {
+                        Bukkit.broadcastMessage(String.format("Size of %s hitbox: %d, Size of %s hitbox: %d", this.craft.getType().getCraftName(), newHitBox.size(), craft.getType().getCraftName(), craft.getHitBox().size()));
+                    }
                     craft.getHitBox().removeAll(oldHitBox);
                     craft.getHitBox().addAll(newHitBox);
+                    if (Settings.Debug){
+                        Bukkit.broadcastMessage(String.format("Hitbox of craft %s intersects hitbox of craft %s", this.craft.getType().getCraftName(), craft.getType().getCraftName()));
+                        Bukkit.broadcastMessage(String.format("Size of %s hitbox: %d, Size of %s hitbox: %d", this.craft.getType().getCraftName(), newHitBox.size(), craft.getType().getCraftName(), craft.getHitBox().size()));
+                    }
                     break;
                 }
             }
         }
+
 
     }
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -1,6 +1,5 @@
 package net.countercraft.movecraft.async.translation;
 
-import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.async.AsyncTask;
 import net.countercraft.movecraft.craft.Craft;
@@ -23,7 +22,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
@@ -192,7 +190,7 @@ public class TranslationTask extends AsyncTask {
                 float explosionKey;
                 float explosionForce = craft.getType().getCollisionExplosion();
                 if (craft.getType().getFocusedExplosion()) {
-                    explosionForce *= oldHitBox.size();
+                    explosionForce *= Math.min(oldHitBox.size(), craft.getType().getMaxSize());
                 }
                 //TODO: Account for underwater explosions
                 /*if (location.getY() < waterLine) { // underwater explosions require more force to do anything
@@ -245,7 +243,6 @@ public class TranslationTask extends AsyncTask {
                 CraftManager.getInstance().addReleaseTask(craft);
         }
         captureYield(harvestedBlocks);
-
     }
 
     private static HitBox translateHitBox(HitBox hitBox, MovecraftLocation shift){

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -1,6 +1,5 @@
 package net.countercraft.movecraft.mapUpdater.update;
 
-import com.google.common.collect.Sets;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.WorldHandler;
@@ -8,11 +7,7 @@ import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.events.SignTranslateEvent;
-import net.countercraft.movecraft.utils.CollectionUtils;
-import net.countercraft.movecraft.utils.HashHitBox;
-import net.countercraft.movecraft.utils.HitBox;
-import net.countercraft.movecraft.utils.MutableHitBox;
-import net.countercraft.movecraft.utils.SolidHitBox;
+import net.countercraft.movecraft.utils.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -173,6 +168,7 @@ public class CraftTranslateCommand extends UpdateCommand {
                 }
             }
         }
+
         if (!craft.isNotProcessing())
             craft.setProcessing(false);
         time = System.nanoTime() - time;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/ExplosionUpdateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/ExplosionUpdateCommand.java
@@ -3,6 +3,8 @@ package net.countercraft.movecraft.mapUpdater.update;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import net.countercraft.movecraft.Movecraft;
+import net.countercraft.movecraft.config.Settings;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
 import java.util.Objects;
@@ -31,6 +33,9 @@ public class ExplosionUpdateCommand extends UpdateCommand {
     public void doUpdate() {
         //if (explosionStrength > 0) { // don't bother with tiny explosions
         //Location loc = new Lo cation(explosionLocation.getWorld(), explosionLocation.getX() + 0.5, explosionLocation.getY() + 0.5, explosionLocation.getZ());
+        if (Settings.Debug){
+            Bukkit.broadcastMessage("Explosion strength: " + explosionStrength + " at " + explosionLocation.toVector().toString());
+        }
         this.createExplosion(explosionLocation.add(.5,.5,.5), explosionStrength);
         //}
 

--- a/modules/api/src/main/java/net/countercraft/movecraft/MovecraftRepair.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/MovecraftRepair.java
@@ -586,8 +586,8 @@ public class MovecraftRepair {
         HashHitBox hitBox = craft.getHitBox();
         World w = craft.getW();
         for (MovecraftLocation location : hitBox) {
-            Integer id = w.getBlockTypeIdAt(location.getX(), location.getY(), location.getZ());
-            Byte data = w.getBlockAt(location.getX(), location.getY(), location.getZ()).getData();
+            int id = w.getBlockTypeIdAt(location.toBukkit(w));
+            byte data = w.getBlockAt(location.getX(), location.getY(), location.getZ()).getData();
             returnSet.add(new BaseBlock(id, data));
         }
         if (Settings.Debug) {

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -17,7 +17,6 @@
 
 package net.countercraft.movecraft.craft;
 
-import net.countercraft.movecraft.MovecraftLocation;
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.Yaml;


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
In this pull request, hitbox size is capped at the max size of the weapon craft to avoid it creating nuke-like explosions due to the large hitbox created from merges from other crafts

<!-- Delete if not aplicable -->
### Related issues:
- #79 Nuka-Torpedo

### Checklist
- [x] Unit tests <!-- if implementing API utilities -->
- [x] Proper internationalization
- [x] Compiled/tested
