### PR TITLE
Repair fix

### DIFF
--- a/modules/api/src/main/java/net/countercraft/movecraft/MovecraftRepair.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/MovecraftRepair.java
@@ -194,8 +194,8 @@ public class MovecraftRepair {
         Vector size = clipboard.getDimensions();
         Vector offset = new Vector(sign.getX() - distance.getBlockX(), sign.getY() - distance.getBlockY(), sign.getZ() - distance.getBlockZ());
         for (int x = 0; x <= size.getBlockX(); x++) {
-            for (int y = 0; y <= size.getBlockY(); y++) {
-                for (int z = 0; z <= size.getBlockZ(); z++) {
+            for (int z = 0; z <= size.getBlockZ(); z++) {
+                for (int y = 0; y <= size.getBlockY(); y++) {
                     Vector position = new Vector(minPos.getBlockX() + x, minPos.getBlockY() + y, minPos.getBlockZ() + z);
                     Location bukkitLoc = new Location(sign.getWorld(), offset.getBlockX() + x, offset.getBlockY() + y, offset.getBlockZ() + z);
                     BaseBlock block = clipboard.getBlock(position);

--- a/modules/api/src/main/java/net/countercraft/movecraft/MovecraftRepair.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/MovecraftRepair.java
@@ -4,9 +4,7 @@ package net.countercraft.movecraft;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.ListTag;
 import com.sk89q.jnbt.Tag;
-import com.sk89q.worldedit.MaxChangedBlocksException;
-import com.sk89q.worldedit.Vector;
-import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.*;
 import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.extent.Extent;
@@ -26,8 +24,11 @@ import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.utils.CollectionUtils;
 import net.countercraft.movecraft.utils.HashHitBox;
+import net.countercraft.movecraft.utils.HitBox;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.bukkit.Location;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.Dispenser;
@@ -80,22 +81,28 @@ public class MovecraftRepair {
         repairName += ".schematic";
         File repairStateFile = new File(playerDirectory, repairName);
         Set<BaseBlock> blockSet = baseBlocksFromCraft(craft);
-        try {
+        HitBox outsideBlocks = CollectionUtils.filter(solidBlockLocs(craft.getW(), cRegion), craft.getHitBox());//Blocks not part of the craft's hitbox
+        EditSession source = WorldEdit.getInstance().getEditSessionFactory().getEditSession(weWorld, -1);
+        BlockArrayClipboard clipboard = new BlockArrayClipboard(cRegion);
+        clipboard.setOrigin(origin);
+        ForwardExtentCopy copy = new ForwardExtentCopy(source, cRegion, clipboard.getOrigin(), clipboard, clipboard.getOrigin());
+        BlockMask mask = new BlockMask(source, blockSet);
+        copy.setSourceMask(mask);
 
-            BlockArrayClipboard clipboard = new BlockArrayClipboard(cRegion);
-            clipboard.setOrigin(origin);
-            Extent source = WorldEdit.getInstance().getEditSessionFactory().getEditSession(weWorld, -1);
-            Extent destination = clipboard;
-            ForwardExtentCopy copy = new ForwardExtentCopy(source, cRegion, clipboard.getOrigin(), destination, clipboard.getOrigin());
-            BlockMask mask = new BlockMask(source, blockSet);
-            copy.setSourceMask(mask);
+        try {
             Operations.completeLegacy(copy);
             ClipboardWriter writer = ClipboardFormat.SCHEMATIC.getWriter(new FileOutputStream(repairStateFile, false));
+            //Remove blocks outside a craft's hitbox from the clipboard
+            if (!outsideBlocks.isEmpty()){
+                for (MovecraftLocation ml : outsideBlocks){
+                    clipboard.setBlock(new Vector(ml.getX(), ml.getY(), ml.getZ()), new BaseBlock(0));
+                }
+            }
             writer.write(clipboard, worldData);
             writer.close();
             return true;
 
-        } catch (MaxChangedBlocksException | IOException e) {
+        } catch (IOException | WorldEditException e) {
             e.printStackTrace();
             return false;
         }
@@ -592,6 +599,21 @@ public class MovecraftRepair {
         }
         if (Settings.Debug) {
             Bukkit.getLogger().info(returnSet.toString());
+        }
+        return returnSet;
+    }
+
+    private HashHitBox solidBlockLocs(World w, CuboidRegion cr){
+        HashHitBox returnSet = new HashHitBox();
+        for (int x = cr.getMinimumPoint().getBlockX(); x <= cr.getMaximumPoint().getBlockX(); x++){
+            for (int y = cr.getMinimumPoint().getBlockY(); y <= cr.getMaximumPoint().getBlockY(); y++){
+                for (int z = cr.getMinimumPoint().getBlockZ(); z <= cr.getMaximumPoint().getBlockZ(); z++){
+                    MovecraftLocation ml = new MovecraftLocation(x, y, z);
+                    if (ml.toBukkit(w).getBlock().getType() != Material.AIR){
+                        returnSet.add(ml);
+                    }
+                }
+            }
         }
         return returnSet;
     }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
In this pull request, a bug allowing blocks allowed on crafts that are not part of them to be included in repair states is fixed. Also, the order of how blocks are placed during repairs is changed


### Checklist
- [x] Unit tests <!-- if implementing API utilities -->
- [x] Proper internationalization
- [x] Compiled/tested
