### PR TITLE
canHoverOverWater fix

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -163,14 +163,14 @@ public class TranslationTask extends AsyncTask {
             } //END OF: if (blockObstructed)
         }
 
-        if (craft.getType().getCantHoverOverBlocks().size() > 0){
+        if (craft.getType().getForbiddenHoverOverBlocks().size() > 0){
             MovecraftLocation test = new MovecraftLocation(newHitBox.getMidPoint().getX(), newHitBox.getMinY(), newHitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
             while (test.toBukkit(craft.getW()).getBlock().getType() == Material.AIR){
                 test = test.translate(0, -1, 0);
             }
             Material testType = test.toBukkit(craft.getW()).getBlock().getType();
-            if (craft.getType().getCantHoverOverBlocks().contains(testType)){
+            if (craft.getType().getForbiddenHoverOverBlocks().contains(testType)){
                 fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over block"), testType.name().toLowerCase().replace("_", " ")));
             }
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -163,15 +163,15 @@ public class TranslationTask extends AsyncTask {
             } //END OF: if (blockObstructed)
         }
 
-        if (!craft.getType().getCanHoverOverWater()){
+        if (craft.getType().getCantHoverOverBlocks().size() > 0){
             MovecraftLocation test = new MovecraftLocation(newHitBox.getMidPoint().getX(), newHitBox.getMinY(), newHitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
             while (test.toBukkit(craft.getW()).getBlock().getType() == Material.AIR){
                 test = test.translate(0, -1, 0);
             }
             Material testType = test.toBukkit(craft.getW()).getBlock().getType();
-            if (craft.getType().getPassthroughBlocks().contains(testType)){
-                fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over passthrough block"), testType.name().toLowerCase().replace("_", " ")));
+            if (craft.getType().getCantHoverOverBlocks().contains(testType)){
+                fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over block"), testType.name().toLowerCase().replace("_", " ")));
             }
         }
         //call event

--- a/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
+++ b/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
@@ -204,7 +204,7 @@ Translation\ -\ Failed\ Craft\ Is\ Disabled=Craft Is Disabled!
 Translation\ -\ Failed\ Craft\ is\ obstructed=The craft cannot move because its path is obstructed\!
 Translation\ -\ Failed\ Craft\ out\ of\ fuel=The craft is out of fuel\!
 Translation\ -\ Failed\ Craft\ hit\ minimum\ height\ limit=Craft has hit the minimum height limit
-Translation\ -\ Failed\ Craft\ over\ passthrough\ block=This craft cannot move over %s\!
+Translation\ -\ Failed\ Craft\ over\ block=This craft cannot move over %s\!
 Translation\ -\ WorldGuard\ -\ Not\ Permitted\ To\ Build=Translation Failed - Player is not permitted to build in this WorldGuard region
 Translation\ -\ Failed\ Craft\ Cannot\ Step\ Up=This craft is obstructed or the incline is too high\!
 

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -88,6 +88,7 @@ final public class CraftType {
     @NotNull private final List<Material> harvestBlocks;
     @NotNull private final List<Material> harvesterBladeBlocks;
     @NotNull private final Set<Material> passthroughBlocks;
+    @NotNull private final Set<Material> cantHoverOverBlocks;
 
     public CraftType(File f) {
         final Map data;
@@ -397,6 +398,21 @@ final public class CraftType {
         if(!blockedByWater){
             passthroughBlocks.add(Material.WATER);
             passthroughBlocks.add(Material.STATIONARY_WATER);
+        }
+        cantHoverOverBlocks = new HashSet<>();
+        if (data.containsKey("cantHoverOverBlocks")){
+            final ArrayList objList = (ArrayList) data.get("cantHoverOverBlocks");
+            for (Object i : objList){
+                if (i instanceof Integer){
+                    cantHoverOverBlocks.add(Material.getMaterial((int) i));
+                } else if (i instanceof String){
+                    cantHoverOverBlocks.add(Material.getMaterial(((String) i).toUpperCase()));
+                }
+            }
+        }
+        if (!canHoverOverWater){
+            cantHoverOverBlocks.add(Material.WATER);
+            cantHoverOverBlocks.add(Material.STATIONARY_WATER);
         }
         if (data.containsKey("allowVerticalTakeoffAndLanding")) {
             allowVerticalTakeoffAndLanding = (Boolean) data.get("allowVerticalTakeoffAndLanding");
@@ -787,6 +803,11 @@ final public class CraftType {
 
     public boolean getOnlyMovePlayers() {
         return onlyMovePlayers;
+    }
+
+    @NotNull
+    public Set<Material> getCantHoverOverBlocks() {
+        return cantHoverOverBlocks;
     }
 
     private class TypeNotFoundException extends RuntimeException {

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -88,7 +88,7 @@ final public class CraftType {
     @NotNull private final List<Material> harvestBlocks;
     @NotNull private final List<Material> harvesterBladeBlocks;
     @NotNull private final Set<Material> passthroughBlocks;
-    @NotNull private final Set<Material> cantHoverOverBlocks;
+    @NotNull private final Set<Material> forbiddenHoverOverBlocks;
 
     public CraftType(File f) {
         final Map data;
@@ -399,20 +399,20 @@ final public class CraftType {
             passthroughBlocks.add(Material.WATER);
             passthroughBlocks.add(Material.STATIONARY_WATER);
         }
-        cantHoverOverBlocks = new HashSet<>();
-        if (data.containsKey("cantHoverOverBlocks")){
-            final ArrayList objList = (ArrayList) data.get("cantHoverOverBlocks");
+        forbiddenHoverOverBlocks = new HashSet<>();
+        if (data.containsKey("forbiddenHoverOverBlocks")){
+            final ArrayList objList = (ArrayList) data.get("forbiddenHoverOverBlocks");
             for (Object i : objList){
                 if (i instanceof Integer){
-                    cantHoverOverBlocks.add(Material.getMaterial((int) i));
+                    forbiddenHoverOverBlocks.add(Material.getMaterial((int) i));
                 } else if (i instanceof String){
-                    cantHoverOverBlocks.add(Material.getMaterial(((String) i).toUpperCase()));
+                    forbiddenHoverOverBlocks.add(Material.getMaterial(((String) i).toUpperCase()));
                 }
             }
         }
         if (!canHoverOverWater){
-            cantHoverOverBlocks.add(Material.WATER);
-            cantHoverOverBlocks.add(Material.STATIONARY_WATER);
+            forbiddenHoverOverBlocks.add(Material.WATER);
+            forbiddenHoverOverBlocks.add(Material.STATIONARY_WATER);
         }
         if (data.containsKey("allowVerticalTakeoffAndLanding")) {
             allowVerticalTakeoffAndLanding = (Boolean) data.get("allowVerticalTakeoffAndLanding");
@@ -806,8 +806,8 @@ final public class CraftType {
     }
 
     @NotNull
-    public Set<Material> getCantHoverOverBlocks() {
-        return cantHoverOverBlocks;
+    public Set<Material> getForbiddenHoverOverBlocks() {
+        return forbiddenHoverOverBlocks;
     }
 
     private class TypeNotFoundException extends RuntimeException {


### PR DESCRIPTION
### Describe in detail what your pull request acomplishes
In this pull request, I have added a new craft flag called cantHoverOverBlocks. A craft will not be able to hover over blocks listed in this flag. Additionally, setting canHoverOverWater to false adds water to cantHoverOverBlocks instead of preventing crafts to move over phasable blocks

### Related issues:
- Fixes #183 
- Fixes #179

### Checklist
- [x] Unit tests <!-- if implementing API utilities -->
- [x] Proper internationalization
- [x] Compiled/tested
