### PR TITLE
Made ascend/cruise/descend signs auto update when one of them is changed

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/ICraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/ICraft.java
@@ -127,8 +127,16 @@ public class ICraft extends Craft {
             else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")){
                 sign.setLine(0, "Ascend: OFF");
             }
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: OFF")
+                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase("Ascend: ON")){
+                sign.setLine(0, "Ascend: ON");
+            }
             else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")){
                 sign.setLine(0, "Descend: OFF");
+            }
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: OFF")
+                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase("Descend: ON")){
+                sign.setLine(0, "Descend: ON");
             }
             sign.update();
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/ICraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/ICraft.java
@@ -7,11 +7,16 @@ import net.countercraft.movecraft.async.detection.DetectionTask;
 import net.countercraft.movecraft.async.rotation.RotationTask;
 import net.countercraft.movecraft.async.translation.TranslationTask;
 import net.countercraft.movecraft.localisation.I18nSupport;
+import org.bukkit.ChatColor;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
+
+import static net.countercraft.movecraft.utils.SignUtils.getFacing;
 
 public class ICraft extends Craft {
     private final UUID id = UUID.randomUUID();
@@ -98,6 +103,35 @@ public class ICraft extends Craft {
     @Override
     public void rotate(Rotation rotation, MovecraftLocation originPoint, boolean isSubCraft) {
         Movecraft.getInstance().getAsyncManager().submitTask(new RotationTask(this, originPoint, rotation, this.getW(), isSubCraft), this);
+    }
+
+    @Override
+    public void resetSigns(@NotNull Sign clicked) {
+        for (final MovecraftLocation ml : hitBox) {
+            final Block b = ml.toBukkit(w).getBlock();
+            if (!(b.getState() instanceof Sign)) {
+                continue;
+            }
+            final Sign sign = (Sign) b.getState();
+            if (sign.equals(clicked)) {
+                continue;
+            }
+            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: ON")){
+                sign.setLine(0, "Cruise: OFF");
+            }
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: OFF")
+                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase("Cruise: ON")
+                    && getFacing(sign) == getFacing(clicked)) {
+                    sign.setLine(0,"Cruise: ON");
+            }
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")){
+                sign.setLine(0, "Ascend: OFF");
+            }
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")){
+                sign.setLine(0, "Descend: OFF");
+            }
+            sign.update();
+        }
     }
 
     @Override

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
@@ -54,9 +54,10 @@ public class AscendSign implements Listener {
             sign.setLine(0, "Ascend: ON");
             sign.update(true);
 
-            CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).setCruiseDirection((byte) 0x42);
-            CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).setLastCruiseUpdate(System.currentTimeMillis());
-            CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).setCruising(true);
+            c.setCruiseDirection((byte) 0x42);
+            c.setLastCruiseUpdate(System.currentTimeMillis());
+            c.setCruising(true);
+            c.resetSigns(sign);
 
             if (!c.getType().getMoveEntities()) {
                 CraftManager.getInstance().addReleaseTask(c);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
@@ -67,11 +67,15 @@ public class AscendSign implements Listener {
         if (!ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")) {
             return;
         }
-        if (CraftManager.getInstance().getCraftByPlayer(event.getPlayer()) == null || !CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).getType().getCanCruise()) {
+        Craft c = CraftManager.getInstance().getCraftByPlayer(event.getPlayer());
+        if (c == null || !c.getType().getCanCruise()) {
             return;
         }
         sign.setLine(0, "Ascend: OFF");
         sign.update(true);
-        CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).setCruising(false);
+
+        c.setCruising(false);
+        c.resetSigns(sign);
+
     }
 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -70,9 +70,11 @@ public final class CruiseSign implements Listener{
         if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: ON")
                 && CraftManager.getInstance().getCraftByPlayer(event.getPlayer()) != null
                 && CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).getType().getCanCruise()) {
+            Craft c = CraftManager.getInstance().getCraftByPlayer(event.getPlayer());
             sign.setLine(0, "Cruise: OFF");
             sign.update(true);
-            CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).setCruising(false);
+            c.setCruising(false);
+            c.resetSigns(sign);
         }
     }
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -61,6 +61,7 @@ public final class CruiseSign implements Listener{
             c.setCruiseDirection(sign.getRawData());
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
+            c.resetSigns(sign);
             if (!c.getType().getMoveEntities()) {
                 CraftManager.getInstance().addReleaseTask(c);
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
@@ -56,6 +56,7 @@ public final class DescendSign implements Listener{
             c.setCruiseDirection((byte) 0x43);
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
+            c.resetSigns(sign);
 
             if (!c.getType().getMoveEntities()) {
                 CraftManager.getInstance().addReleaseTask(c);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
@@ -69,6 +69,7 @@ public final class DescendSign implements Listener{
                 sign.setLine(0, "Descend: OFF");
                 sign.update(true);
                 c.setCruising(false);
+                c.resetSigns(sign);
             }
         }
     }

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -27,6 +27,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +36,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+
 
 public abstract class Craft {
     @NotNull protected final CraftType type;
@@ -424,4 +427,6 @@ public abstract class Craft {
     public HashHitBox getCollapsedHitBox() {
         return collapsedHitBox;
     }
+
+    public abstract void resetSigns(@NotNull final Sign clicked);
 }


### PR DESCRIPTION

<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
In this pull request, I am fixing an issue that Cruise, Ascend and descend signs do not auto update when another of these signs are changed. For example: A Cruise sign is ON while I click an Ascend sign. Instead of the cruise sign turning to off, it remains on. 

In addition to fix automatically setting other control signs to OFF when a control sign is set to ON, it also sets other cruise signs in the same direction to ON

### Related issues:
- Fixes #199 

### Checklist
- [x] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
