### PR TITLE
Gravity rewrite

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -524,7 +524,7 @@ public class TranslationTask extends AsyncTask {
             dropDistance--;
             for (MovecraftLocation ml : bottomLocs) {
 
-                testType = ml.translate(0, dropDistance, 0).toBukkit(craft.getW()).getBlock().getType();
+                testType = ml.translate(0, dropDistance - 1, 0).toBukkit(craft.getW()).getBlock().getType();
                 if (testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType)) {
                     break;
                 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -90,9 +90,19 @@ public class TranslationTask extends AsyncTask {
             return;
         }
         if (craft.getType().getUseGravity() && !craft.getSinking()){
-            Bukkit.broadcastMessage("Is On Ground: " + isOnGround(oldHitBox));
             if (inclineCraft(oldHitBox)){
-                dy = climbDistance;
+                //Ignore explosive crafts
+                if (craft.getType().getCollisionExplosion() > 0f) {
+                    dy = 0;
+                }
+                else if (craft.getType().getGravityInclineDistance() > -1 && climbDistance > craft.getType().getGravityInclineDistance()) {
+                    fail(I18nSupport.getInternationalisedString("Translation - Failed Incline too steep"));
+                    return;
+
+                } else {
+                    dy = climbDistance;
+                }
+
             } else if (!isOnGround(oldHitBox) && craft.getType().getCanHover()){
                 MovecraftLocation midPoint = oldHitBox.getMidPoint();
                 int centreMinY = oldHitBox.getLocalMinY(midPoint.getX(), midPoint.getZ());
@@ -476,9 +486,6 @@ public class TranslationTask extends AsyncTask {
             if (elevation < surfaceLoc.subtract(ml).getY()) {
                 elevation = surfaceLoc.subtract(ml).getY();
             }
-            if (craft.getType().getGravityInclineDistance() > -1) {
-                elevation = Math.min(elevation, craft.getType().getGravityInclineDistance());
-            }
 
         }
         if (elevation == 0) {
@@ -523,8 +530,6 @@ public class TranslationTask extends AsyncTask {
                 }
             }
         } while (dropDistance > craft.getType().getGravityDropDistance() && testType == Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType));
-
-        Bukkit.broadcastMessage(String.valueOf(dropDistance));
         return dropDistance;
     }
 
@@ -563,7 +568,6 @@ public class TranslationTask extends AsyncTask {
         if (dy > 0){
             return bottomLocsOnGround && translatedBottomLocsInAir;
         }
-        Bukkit.broadcastMessage("Translated bottom locs in air: " + translatedBottomLocsInAir);
         return !translatedBottomLocsInAir;
     }
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -33,7 +33,6 @@ public class TranslationTask extends AsyncTask {
     private boolean collisionExplosion = false;
     private String failMessage;
     private Collection<UpdateCommand> updates = new HashSet<>();
-    private int climbDistance = 0;
 
     public TranslationTask(Craft c, int dx, int dy, int dz) {
         super(c);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -519,8 +519,8 @@ public class TranslationTask extends AsyncTask {
                 //This has to be subtracted by one, or non-passthrough blocks will be within the y drop path
                 //obstructing the craft
                 Material testType = ml.translate(0, dropDistance - 1, 0).toBukkit(craft.getW()).getBlock().getType();
-                if (testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType)) {
-                    hitGround = true;
+                hitGround = testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType);
+                if (hitGround) {
                     break;
                 }
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -507,7 +507,7 @@ public class TranslationTask extends AsyncTask {
                 continue;
             }
             //Otherwise, add to bottom locations
-            bottomLocs.add(location);
+            bottomLocs.add(location.translate(0, -1, 0));
         }
         int dropDistance = 0;
 
@@ -517,7 +517,7 @@ public class TranslationTask extends AsyncTask {
             for (MovecraftLocation ml : bottomLocs) {
                 //This has to be subtracted by one, or non-passthrough blocks will be within the y drop path
                 //obstructing the craft
-                Material testType = ml.translate(0, dropDistance - 1, 0).toBukkit(craft.getW()).getBlock().getType();
+                Material testType = ml.translate(0, dropDistance , 0).toBukkit(craft.getW()).getBlock().getType();
                 hitGround = testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType);
                 if (hitGround) {
                     break;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -516,6 +516,8 @@ public class TranslationTask extends AsyncTask {
         do {
             dropDistance--;
             for (MovecraftLocation ml : bottomLocs) {
+                //This has to be subtracted by one, or non-passthrough blocks will be within the y drop path
+                //obstructing the craft
                 testType = ml.translate(0, dropDistance - 1, 0).toBukkit(craft.getW()).getBlock().getType();
                 if (testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType)) {
                     break;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -107,9 +107,12 @@ public class TranslationTask extends AsyncTask {
         if (dy>0 && maxY + dy > craft.getType().getMaxHeightLimit()) {
             fail(I18nSupport.getInternationalisedString("Translation - Failed Craft hit height limit"));
             return;
-        } else if (minY + dy < craft.getType().getMinHeightLimit() && dy < 0 && !craft.getSinking()) {
+        } else if (minY + dy < craft.getType().getMinHeightLimit() && dy < 0 && !craft.getSinking() && !craft.getType().getUseGravity()) {
             fail(I18nSupport.getInternationalisedString("Translation - Failed Craft hit minimum height limit"));
             return;
+        } else if (minY + dy < craft.getType().getMinHeightLimit() && dy < 0 && craft.getType().getUseGravity()) {
+            //if a craft using gravity hits the minimum height limit, set dy = 0 instead of failing
+            dy = 0;
         }
 
         //TODO: Check fuel

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -72,21 +72,7 @@ public class TranslationTask extends AsyncTask {
                 dy = Math.min(dy,-1);
             }
         }
-
-        //Fail the movement if the craft is too high
-        if (dy>0 && maxY + dy > craft.getType().getMaxHeightLimit()) {
-            fail(I18nSupport.getInternationalisedString("Translation - Failed Craft hit height limit"));
-            return;
-        } else if (minY + dy < craft.getType().getMinHeightLimit() && dy < 0 && !craft.getSinking()) {
-            fail(I18nSupport.getInternationalisedString("Translation - Failed Craft hit minimum height limit"));
-            return;
-        }
-
-        //TODO: Check fuel
-        if (!checkFuel()) {
-            fail(I18nSupport.getInternationalisedString("Translation - Failed Craft out of fuel"));
-            return;
-        }
+        //Process gravity
         if (craft.getType().getUseGravity() && !craft.getSinking()){
             int incline = inclineCraft(oldHitBox);
             if (incline > 0){
@@ -117,6 +103,21 @@ public class TranslationTask extends AsyncTask {
                 dy = dropDistance(oldHitBox);
             }
         }
+        //Fail the movement if the craft is too high
+        if (dy>0 && maxY + dy > craft.getType().getMaxHeightLimit()) {
+            fail(I18nSupport.getInternationalisedString("Translation - Failed Craft hit height limit"));
+            return;
+        } else if (minY + dy < craft.getType().getMinHeightLimit() && dy < 0 && !craft.getSinking()) {
+            fail(I18nSupport.getInternationalisedString("Translation - Failed Craft hit minimum height limit"));
+            return;
+        }
+
+        //TODO: Check fuel
+        if (!checkFuel()) {
+            fail(I18nSupport.getInternationalisedString("Translation - Failed Craft out of fuel"));
+            return;
+        }
+
 
         //TODO: Add and handle event for towny and factions
         final List<Material> harvestBlocks = craft.getType().getHarvestBlocks();
@@ -455,13 +456,14 @@ public class TranslationTask extends AsyncTask {
     private MovecraftLocation surfaceLoc(MovecraftLocation ml) {
         MovecraftLocation surfaceLoc = ml;
         Material testType;
+        boolean hitSurface = false;
         do {
             surfaceLoc = surfaceLoc.translate(0, 1, 0);
-            if (surfaceLoc.getY() + 1 > craft.getType().getMaxHeightLimit()) {
-                break;
-            }
             testType = surfaceLoc.toBukkit(craft.getW()).getBlock().getType();
-        } while (testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType) && !oldHitBox.contains(surfaceLoc));
+        } while ((testType != Material.AIR &&
+                !craft.getType().getPassthroughBlocks().contains(testType) &&
+                !oldHitBox.contains(surfaceLoc)) &&
+                surfaceLoc.getY() + 1 > craft.getType().getMaxHeightLimit());
         return surfaceLoc;
     }
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -513,7 +513,7 @@ public class TranslationTask extends AsyncTask {
 
         do {
             boolean hitGround = false;
-            dropDistance--;
+
             for (MovecraftLocation ml : bottomLocs) {
                 //This has to be subtracted by one, or non-passthrough blocks will be within the y drop path
                 //obstructing the craft
@@ -526,6 +526,7 @@ public class TranslationTask extends AsyncTask {
             if (hitGround) {
                 break;
             }
+            dropDistance--;
         } while (dropDistance > craft.getType().getGravityDropDistance());
         return dropDistance;
     }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -511,19 +511,23 @@ public class TranslationTask extends AsyncTask {
             bottomLocs.add(location);
         }
         int dropDistance = 0;
-        Material testType = null;
 
         do {
+            boolean hitGround = false;
             dropDistance--;
             for (MovecraftLocation ml : bottomLocs) {
                 //This has to be subtracted by one, or non-passthrough blocks will be within the y drop path
                 //obstructing the craft
-                testType = ml.translate(0, dropDistance - 1, 0).toBukkit(craft.getW()).getBlock().getType();
+                Material testType = ml.translate(0, dropDistance - 1, 0).toBukkit(craft.getW()).getBlock().getType();
                 if (testType != Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType)) {
+                    hitGround = true;
                     break;
                 }
             }
-        } while (dropDistance > craft.getType().getGravityDropDistance() && testType == Material.AIR && !craft.getType().getPassthroughBlocks().contains(testType));
+            if (hitGround) {
+                break;
+            }
+        } while (dropDistance > craft.getType().getGravityDropDistance());
         return dropDistance;
     }
 

--- a/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
+++ b/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
@@ -201,6 +201,7 @@ Startup\ -\ Vault\ Found=Found a compatible Vault plugin. Enabling Vault integra
 Startup\ -\ Vault\ Not\ Found=Movecraft did not find a compatible Vault plugin. Disabling Vault integration.
 Translation\ -\ Failed\ Craft\ hit\ height\ limit=Craft has hit the height limit
 Translation\ -\ Failed\ Craft\ Is\ Disabled=Craft Is Disabled!
+Translation\ -\ Failed\ Incline\ too\ steep=The craft cannot move because the incline is too steep\!
 Translation\ -\ Failed\ Craft\ is\ obstructed=The craft cannot move because its path is obstructed\!
 Translation\ -\ Failed\ Craft\ out\ of\ fuel=The craft is out of fuel\!
 Translation\ -\ Failed\ Craft\ hit\ minimum\ height\ limit=Craft has hit the minimum height limit

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -152,10 +152,11 @@ final public class CraftType {
         explodeOnCrash = floatFromObject(data.getOrDefault("explodeOnCrash", 0F));
         collisionExplosion = floatFromObject(data.getOrDefault("collisionExplosion", 0F));
         minHeightLimit = Math.max(0, integerFromObject(data.getOrDefault("minHeightLimit", 0)));
-        int value = integerFromObject(data.getOrDefault("maxHeightLimit", 254));
+        int value = Math.min(integerFromObject(data.getOrDefault("maxHeightLimit", 254)), 255);
         if (value <= minHeightLimit) {
             value = 255;
         }
+
         maxHeightLimit = value;
         maxHeightAboveGround = integerFromObject(data.getOrDefault("maxHeightAboveGround", -1));
         canDirectControl = (boolean) data.getOrDefault("canDirectControl", true);

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -89,6 +89,8 @@ final public class CraftType {
     @NotNull private final List<Material> harvesterBladeBlocks;
     @NotNull private final Set<Material> passthroughBlocks;
     @NotNull private final Set<Material> forbiddenHoverOverBlocks;
+    private final int gravityDropDistance;
+    private final int gravityInclineDistance;
 
     @SuppressWarnings("unchecked")
     public CraftType(File f) {
@@ -228,6 +230,9 @@ final public class CraftType {
         dynamicFlyBlockSpeedFactor = doubleFromObject(data.getOrDefault("dynamicFlyBlockSpeedFactor", 0d));
         dynamicFlyBlock = integerFromObject(data.getOrDefault("dynamicFlyBlock", 0));
         chestPenalty = doubleFromObject(data.getOrDefault("chestPenalty", 0));
+        gravityInclineDistance = integerFromObject(data.getOrDefault("gravityInclineDistance", -1));
+        int dropdist = integerFromObject(data.getOrDefault("gravityDropDistance", -8));
+        gravityDropDistance = dropdist > 0 ? -dropdist : dropdist;
     }
 
     private int integerFromObject(Object obj) {
@@ -610,6 +615,14 @@ final public class CraftType {
     @NotNull
     public Set<Material> getForbiddenHoverOverBlocks() {
         return forbiddenHoverOverBlocks;
+    }
+
+    public int getGravityDropDistance() {
+        return gravityDropDistance;
+    }
+
+    public int getGravityInclineDistance() {
+        return gravityInclineDistance;
     }
 
     private class TypeNotFoundException extends RuntimeException {

--- a/modules/api/src/main/java/net/countercraft/movecraft/utils/HashHitBox.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/utils/HashHitBox.java
@@ -103,7 +103,7 @@ public class HashHitBox implements MutableHitBox {
         }
         int yValue=-1;
         for(MovecraftLocation location : locationSet){
-            if(location.getX()==x && location.getZ() ==z && (yValue==-1 || location.getY()>yValue)){
+            if(location.getX()==x && location.getZ() ==z && (yValue==-1 || location.getY() < yValue)){
                 yValue=location.getY();
             }
         }

--- a/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
+++ b/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
@@ -1,12 +1,12 @@
 package net.countercraft.movecraft.compat.v1_12_R1;
 
+import net.countercraft.movecraft.config.Settings;
+import net.countercraft.movecraft.utils.MathUtils;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
-import net.countercraft.movecraft.WorldHandler;
-import net.countercraft.movecraft.config.Settings;
-import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.utils.CollectionUtils;
-import net.countercraft.movecraft.utils.MathUtils;
+import net.countercraft.movecraft.WorldHandler;
+import net.countercraft.movecraft.craft.Craft;
 import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
+++ b/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
@@ -235,7 +235,7 @@ public class IWorldHandler extends WorldHandler {
         //*       Step six: Update the blocks       *
         //*******************************************
         for(BlockPosition newPosition : newPositions) {
-            CraftBlockState.getBlockState(nativeWorld,newPosition.getX(), newPosition.getY(), newPosition.getZ()).update(false,false);
+            CraftBlockState.getBlockState(nativeWorld,newPosition.getX(), newPosition.getY(), newPosition.getZ()).update(false, false);
         }
         for(BlockPosition deletedPosition : deletePositions){
             CraftBlockState.getBlockState(nativeWorld,deletedPosition.getX(), deletedPosition.getY(), deletedPosition.getZ()).update(false,false);

--- a/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
+++ b/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
@@ -1,12 +1,12 @@
 package net.countercraft.movecraft.compat.v1_12_R1;
 
-import net.countercraft.movecraft.config.Settings;
-import net.countercraft.movecraft.utils.MathUtils;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
-import net.countercraft.movecraft.utils.CollectionUtils;
 import net.countercraft.movecraft.WorldHandler;
+import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.utils.CollectionUtils;
+import net.countercraft.movecraft.utils.MathUtils;
 import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
+++ b/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
@@ -1,17 +1,16 @@
 package net.countercraft.movecraft.compat.v1_12_R1;
 
-import net.countercraft.movecraft.config.Settings;
-import net.countercraft.movecraft.utils.MathUtils;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
-import net.countercraft.movecraft.utils.CollectionUtils;
 import net.countercraft.movecraft.WorldHandler;
+import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.utils.CollectionUtils;
+import net.countercraft.movecraft.utils.MathUtils;
 import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_12_R1.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_12_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Player;


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
This pull request implements an overhaul to the gravity system in Movecraft
### Additions:
**New craft type flags:**
- __gravityInclineDistance__ : Limits how far a craft can move up in y direction. Default value is -1 (no limit)
- __gravityDropDistance__ : Limits how far a craft can drop per translation. Default value is 10.

#### Changes:
- gravity incline processing now ignores explosive crafts (such as torpedoes, missiles, etc...)
- Gravity system is much more cruise-friendly now
- fixed getLocalMinY() to return a min Y instead of a max Y value


 

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
- 

### Checklist
- [x] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
