### PR TITLE
Reset coloration to craft names

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -964,7 +964,7 @@ public class AsyncManager extends BukkitRunnable {
 
                                         if (tcraft.getName().length() >= 1){
                                             notification += tcraft.getName();
-				notification += ChatColor.RESET;
+						notification += ChatColor.RESET;
                                             notification += " (";
                                         }
                                         notification += tcraft.getType().getCraftName();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -964,7 +964,7 @@ public class AsyncManager extends BukkitRunnable {
 
                                         if (tcraft.getName().length() >= 1){
                                             notification += tcraft.getName();
-											notification += ChatColor.RESET
+				notification += ChatColor.RESET;
                                             notification += " (";
                                         }
                                         notification += tcraft.getType().getCraftName();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -964,6 +964,7 @@ public class AsyncManager extends BukkitRunnable {
 
                                         if (tcraft.getName().length() >= 1){
                                             notification += tcraft.getName();
+											notification += ChatColor.RESET
                                             notification += " (";
                                         }
                                         notification += tcraft.getType().getCraftName();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -964,7 +964,7 @@ public class AsyncManager extends BukkitRunnable {
 
                                         if (tcraft.getName().length() >= 1){
                                             notification += tcraft.getName();
-					notification += ChatColor.RESET;
+					    notification += ChatColor.RESET;
                                             notification += " (";
                                         }
                                         notification += tcraft.getType().getCraftName();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -964,7 +964,7 @@ public class AsyncManager extends BukkitRunnable {
 
                                         if (tcraft.getName().length() >= 1){
                                             notification += tcraft.getName();
-						notification += ChatColor.RESET;
+					notification += ChatColor.RESET;
                                             notification += " (";
                                         }
                                         notification += tcraft.getType().getCraftName();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -964,7 +964,7 @@ public class AsyncManager extends BukkitRunnable {
 
                                         if (tcraft.getName().length() >= 1){
                                             notification += tcraft.getName();
-					notification += ChatColor.RESET;
+						notification += ChatColor.RESET;
                                             notification += " (";
                                         }
                                         notification += tcraft.getType().getCraftName();


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes

This pull request implements resetting of colors after ship name from Name: sign

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
- fixes #231  

### Checklist
- [x] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
