### PR TITLE
Add millisecond display to /craftreport

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/CraftReportCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/CraftReportCommand.java
@@ -48,7 +48,7 @@ public class CraftReportCommand implements CommandExecutor{
                     hitBox.getMinX() + "," +
                     hitBox.getMinY() + "," +
                     hitBox.getMinZ() + " - " +
-                    craft.getMeanCruiseTime());
+                    String.format("%.2f", 1000 * craft.getMeanCruiseTime()) + "ms");
         }
         if(!paginator.isInBounds(page)){
             commandSender.sendMessage(MOVECRAFT_COMMAND_PREFIX + I18nSupport.getInternationalisedString("Paginator - Invalid page") + "\"" + args[1] + "\"");

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/CraftReportCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/CraftReportCommand.java
@@ -47,7 +47,8 @@ public class CraftReportCommand implements CommandExecutor{
                     hitBox.size() + " @ " +
                     hitBox.getMinX() + "," +
                     hitBox.getMinY() + "," +
-                    hitBox.getMinZ());
+                    hitBox.getMinZ() + " - " +
+                    craft.getMeanCruiseTime());
         }
         if(!paginator.isInBounds(page)){
             commandSender.sendMessage(MOVECRAFT_COMMAND_PREFIX + I18nSupport.getInternationalisedString("Paginator - Invalid page") + "\"" + args[1] + "\"");


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
Add millisecond display to /craftreport, allowing server admins and owners to diagnose server lag per craft.

### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
