### PR TITLE
Remove bypassing of Spigot's safety checks on removing tile entities

### DIFF
--- a/modules/v1_10_R1/src/main/java/net/countercraft/movecraft/compat/v1_10_R1/IWorldHandler.java
+++ b/modules/v1_10_R1/src/main/java/net/countercraft/movecraft/compat/v1_10_R1/IWorldHandler.java
@@ -247,7 +247,7 @@ public class IWorldHandler extends WorldHandler {
 
     @Nullable
     private TileEntity removeTileEntity(@NotNull World world, @NotNull BlockPosition position){
-        TileEntity tile = world.getChunkAtWorldCoords(position).a(position, Chunk.EnumTileEntityState.IMMEDIATE);
+        TileEntity tile = world.getTileEntity(position);
         if(tile == null)
             return null;
         //cleanup
@@ -274,7 +274,7 @@ public class IWorldHandler extends WorldHandler {
         return new BlockPosition(loc.getX(), loc.getY(), loc.getZ());
     }
 
-    private void setBlockFast(@NotNull World world, @NotNull BlockPosition position,@NotNull IBlockData data) {
+    private void setBlockFast(@NotNull World world, @NotNull BlockPosition position, @NotNull IBlockData data) {
         Chunk chunk = world.getChunkAtWorldCoords(position);
         ChunkSection chunkSection = chunk.getSections()[position.getY()>>4];
         if (chunkSection == null) {
@@ -283,12 +283,12 @@ public class IWorldHandler extends WorldHandler {
             chunkSection = chunk.getSections()[position.getY() >> 4];
         }
         if(chunkSection.getType(position.getX()&15, position.getY()&15, position.getZ()&15).equals(data)){
+            //Block is already of correct type and data, don't overwrite
             return;
         }
         chunkSection.setType(position.getX()&15, position.getY()&15, position.getZ()&15, data);
         world.notify(position, data, data, 3);
         chunk.e(); // mark dirty
-
     }
 
     @Override

--- a/modules/v1_11_R1/src/main/java/net/countercraft/movecraft/compat/v1_11_R1/IWorldHandler.java
+++ b/modules/v1_11_R1/src/main/java/net/countercraft/movecraft/compat/v1_11_R1/IWorldHandler.java
@@ -226,7 +226,7 @@ public class IWorldHandler extends WorldHandler {
 
     @Nullable
     private TileEntity removeTileEntity(@NotNull World world, @NotNull BlockPosition position){
-        TileEntity tile = world.getChunkAtWorldCoords(position).a(position, Chunk.EnumTileEntityState.IMMEDIATE);
+        TileEntity tile = world.getTileEntity(position);
         if(tile == null)
             return null;
         //cleanup

--- a/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
+++ b/modules/v1_12_R1/src/main/java/net/countercraft/movecraft/compat/v1_12_R1/IWorldHandler.java
@@ -227,7 +227,7 @@ public class IWorldHandler extends WorldHandler {
 
     @Nullable
     private TileEntity removeTileEntity(@NotNull World world, @NotNull BlockPosition position){
-        TileEntity tile = world.getChunkAtWorldCoords(position).a(position, Chunk.EnumTileEntityState.IMMEDIATE);
+        TileEntity tile = world.getTileEntity(position);
         if(tile == null)
             return null;
         //cleanup


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
This fixes a possible cause of corruption from movecraft.


### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [ ] Proper internationalization
- [x] Compiled/tested
