### PR TITLE
Fixed helm signs to work when near a craft rather than within the hitbox

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/HelmSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/HelmSign.java
@@ -71,9 +71,8 @@ public final class HelmSign implements Listener {
             }
         }*/
 
-        if (!MathUtils.locationInHitBox(craft.getHitBox(), event.getPlayer().getLocation())) {
+        if(!MathUtils.locIsNearCraftFast(craft, MathUtils.bukkit2MovecraftLoc(event.getPlayer().getLocation())))
             return;
-        }
 
         if (craft.getType().rotateAtMidpoint()) {
             CraftManager.getInstance().getCraftByPlayer(event.getPlayer()).rotate(rotation, craft.getHitBox().getMidPoint());


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
Helm signs currently fail to work when the player is standing on the top block of a craft, or within signs on a craft.  (I believe this is due to larger issues in Hitbox boundings, and is only a patch).

This changes the functionality to work within 3 blocks of the hitbox, which creates a much larger area and is still not abusable.

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested