### PR TITLE
Fixed default speed

### DIFF
--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -364,8 +364,8 @@ public abstract class Craft {
 
         if(type.getDynamicLagSpeedFactor() == 0.0 || type.getDynamicLagPowerFactor() == 0.0 || Math.abs(type.getDynamicLagPowerFactor()) > 1.0)
             return type.getCruiseTickCooldown(w) + chestPenalty;
-        if(meanCruiseTime == 0)
-            return type.getCruiseTickCooldown(w) + chestPenalty;
+        if(numMoves == 0)
+            return (int) Math.round(20.0 * ((type.getCruiseSkipBlocks(w) + 1.0) / type.getDynamicLagMinSpeed()));
 
         if(Settings.Debug) {
             Bukkit.getLogger().info("Skip: " + type.getCruiseSkipBlocks(w));


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
While using dynamic speed, the craft always moves at it's max speed until it has cruised straight (abusable to cruise diagonal permanently).  Now they move at their min speed until they have cruised straight atleast once.

### Checklist
- [x] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
