### PR TITLE
Meeting summary fixes.

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/ManOverboardCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/ManOverboardCommand.java
@@ -64,7 +64,7 @@ public class ManOverboardCommand implements CommandExecutor{
     private Location getCraftTeleportPoint(Craft craft) {
         double telX = (craft.getHitBox().getMinX() + craft.getHitBox().getMaxX())/2D;
         double telZ = (craft.getHitBox().getMinZ() + craft.getHitBox().getMaxZ())/2D;
-        double telY = craft.getHitBox().getMaxY();
+        double telY = craft.getHitBox().getMaxY() + 1;
         return new Location(craft.getW(), telX, telY, telZ);
     }
 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
@@ -12,6 +12,7 @@ import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.utils.MathUtils;
 import org.bukkit.*;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -108,6 +109,25 @@ public class CrewSign implements Listener {
         Location respawnLoc = craft.getCrewSigns().get(player.getUniqueId());
         if (!respawnLoc.getBlock().getType().equals(Material.BED_BLOCK)){
             return;
+        }
+        //Attempt to find an empty location to spawn the player
+        boolean locationFound = false;
+        for(int i = -1; i < 2; i++) {
+           for(int j = -1; j < 2; j++) {
+               Location testLoc = new Location(craft.getW(), respawnLoc.getX()+i, respawnLoc.getY(), respawnLoc.getZ()+j);
+               if(testLoc.getBlock().getType().equals(Material.AIR)) {
+                   if(testLoc.getBlock().getRelative(BlockFace.UP).isEmpty() && !testLoc.getBlock().getRelative(BlockFace.DOWN).isEmpty()) {
+                        respawnLoc = testLoc;
+                        locationFound = true;
+                        player.sendMessage("Found a spot to respawn player!");
+                        break;
+                   }
+               }
+           }
+           if (locationFound) {
+               respawnLoc = new Location(craft.getW(), respawnLoc.getX()+0.5, respawnLoc.getY(), respawnLoc.getZ()+0.5);
+               break;
+           }
         }
         event.setRespawnLocation(respawnLoc);
     }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
@@ -119,7 +119,6 @@ public class CrewSign implements Listener {
                    if(testLoc.getBlock().getRelative(BlockFace.UP).isEmpty() && !testLoc.getBlock().getRelative(BlockFace.DOWN).isEmpty()) {
                         respawnLoc = testLoc;
                         locationFound = true;
-                        player.sendMessage("Found a spot to respawn player!");
                         break;
                    }
                }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
@@ -119,12 +119,13 @@ public class CrewSign implements Listener {
                    if(testLoc.getBlock().getRelative(BlockFace.UP).isEmpty() && !testLoc.getBlock().getRelative(BlockFace.DOWN).isEmpty()) {
                         respawnLoc = testLoc;
                         locationFound = true;
+                        player.sendMessage("Found a spot to respawn player!");
                         break;
                    }
                }
            }
            if (locationFound) {
-               respawnLoc = new Location(craft.getW(), respawnLoc.getX()+0.5, respawnLoc.getY(), respawnLoc.getZ()+0.5);
+               respawnLoc = respawnLoc.add(0.5, 0, 0.5);
                break;
            }
         }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
This pull request changes two things:
1) Changes crew bed respawning to find an open space on ground next to the bed and spawn them there rather than spawning them on top of the bed.
2) Teleports the player one block higher when using /manoverboard to prevent them being stuck inside a block.

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
