### PR TITLE
Migrating Fireball Penetration

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -154,7 +154,6 @@ public class Movecraft extends JavaPlugin {
         Settings.SilhouetteViewDistance = getConfig().getInt("SilhouetteViewDistance", 200);
         Settings.SilhouetteBlockCount = getConfig().getInt("SilhouetteBlockCount", 20);
         Settings.SiegeTaskSeconds = getConfig().getInt("SiegeTaskSeconds", 600);
-        Settings.FireballPenetration = getConfig().getBoolean("FireballPenetration", true);
         Settings.ProtectPilotedCrafts = getConfig().getBoolean("ProtectPilotedCrafts", false);
         Settings.AllowCrewSigns = getConfig().getBoolean("AllowCrewSigns", true);
         Settings.SetHomeToCrewSign = getConfig().getBoolean("SetHomeToCrewSign", true);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -33,8 +33,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Hopper;
 import org.bukkit.block.Sign;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -231,39 +229,6 @@ public class BlockListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOW)
-    public void onBlockIgnite(BlockIgniteEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
-        final Craft adjacentCraft = adjacentCraft(event.getBlock().getLocation());
-        // replace blocks with fire occasionally, to prevent fast craft from simply ignoring fire
-        if (Settings.FireballPenetration && event.getCause() == BlockIgniteEvent.IgniteCause.FIREBALL) {
-            Block testBlock = event.getBlock().getRelative(-1, 0, 0);
-            if (!testBlock.getType().isBurnable())
-                testBlock = event.getBlock().getRelative(1, 0, 0);
-            if (!testBlock.getType().isBurnable())
-                testBlock = event.getBlock().getRelative(0, 0, -1);
-            if (!testBlock.getType().isBurnable())
-                testBlock = event.getBlock().getRelative(0, 0, 1);
-
-            if (!testBlock.getType().isBurnable()) {
-                return;
-            }
-            // check to see if fire spread is allowed, don't check if worldguard integration is not enabled
-            if (Movecraft.getInstance().getWorldGuardPlugin() != null && (Settings.WorldGuardBlockMoveOnBuildPerm || Settings.WorldGuardBlockSinkOnPVPPerm)) {
-                ApplicableRegionSet set = Movecraft.getInstance().getWorldGuardPlugin().getRegionManager(testBlock.getWorld()).getApplicableRegions(testBlock.getLocation());
-                if (!set.allows(DefaultFlag.FIRE_SPREAD)) {
-                    return;
-                }
-            }
-            testBlock.setType(org.bukkit.Material.AIR);
-        } else if (adjacentCraft != null) {
-
-            adjacentCraft.getHitBox().add(MathUtils.bukkit2MovecraftLoc(event.getBlock().getLocation()));
-        }
-
-    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBlockDispense(BlockDispenseEvent e) {

--- a/modules/Movecraft/src/main/resources/config.yml
+++ b/modules/Movecraft/src/main/resources/config.yml
@@ -10,7 +10,6 @@ WorldGuardBlockSinkOnPVPPerm: true
 ManOverboardTimeout: 30
 ManOverboardDistance: 1000 # maximum distance from a craft that you can manoverboard to it
 FireballLifespan: 6
-FireballPenetration: true
 ProtectPilotedCrafts: true
 DisableSpillProtection: false
 RequireCreatePerm: false # require users to have the movecract.<CraftTypeName>.create permission in order to place command signs

--- a/modules/api/src/main/java/net/countercraft/movecraft/config/Settings.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/config/Settings.java
@@ -57,7 +57,6 @@ public class Settings {
     public static int BlockQueueChunkSize = 1000;
     public static int SiegeTaskSeconds = 600;
     public static double RepairMoneyPerBlock = 0.0;
-    public static boolean FireballPenetration = true;
     public static boolean AllowCrewSigns = true;
     public static boolean SetHomeToCrewSign = true;
     public static int MaxRemoteSigns = -1;


### PR DESCRIPTION
Removes fireball penetration from the base Movecraft plugin, as part of migrating it to Movecraft-Combat.

<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes:
Removes fireball penetration from the base Movecraft plugin, as part of migrating it to Movecraft-Combat.

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
