### PR TITLE
Added TypesReloadedEvent

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -106,8 +106,8 @@ public class CraftManager implements Iterable<Craft>{
     }
 
     public void initCraftTypes() {
-        Bukkit.getServer().getPluginManager().callEvent(new TypesReloadedEvent());
         this.craftTypes = loadCraftTypes();
+        Bukkit.getServer().getPluginManager().callEvent(new TypesReloadedEvent());
     }
 
     public void addCraft(@NotNull Craft c, @Nullable Player p) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -20,6 +20,7 @@ package net.countercraft.movecraft.craft;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.events.CraftPilotEvent;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
+import net.countercraft.movecraft.events.TypesReloadedEvent;
 import net.countercraft.movecraft.exception.NonCancellableReleaseException;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.Bukkit;
@@ -105,6 +106,7 @@ public class CraftManager implements Iterable<Craft>{
     }
 
     public void initCraftTypes() {
+        Bukkit.getServer().getPluginManager().callEvent(new TypesReloadedEvent());
         this.craftTypes = loadCraftTypes();
     }
 

--- a/modules/api/src/main/java/net/countercraft/movecraft/events/TypesReloadedEvent.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/events/TypesReloadedEvent.java
@@ -1,0 +1,22 @@
+package net.countercraft.movecraft.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class TypesReloadedEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    
+    public TypesReloadedEvent() {
+
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
Currently, when `/movecraft reloadtypes` is run, all currently loaded `CraftType`s are dereferenced and new ones are created in the CraftManager.  This causes problems for addon plugins which reference `CraftType`s (such as Movecraft-Combat for the directors feature), creating a memory leak and functional problems.

### Checklist
- [x] Proper internationalization
- [ ] Compiled/tested
