### PR TITLE
Do not change crew signs if the event has been cancelled.

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CrewSign.java
@@ -27,7 +27,7 @@ public class CrewSign implements Listener {
 
     @EventHandler
     public final void onSignChange(SignChangeEvent event) {
-        if (!event.getLine(0).equalsIgnoreCase("Crew:")) {
+        if (event.isCancelled() || !event.getLine(0).equalsIgnoreCase("Crew:")) {
             return;
         }
         Player player = event.getPlayer();


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
This PR stops the name in the crew sign from being autofilled when the event has been cancelled. This is to give extension plugins like Movecraft-Autosign the ability to control what is on signs if it is needed.

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
