### PR TITLE
Make CruiseDirection an Enum

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -18,6 +18,7 @@
 package net.countercraft.movecraft.async;
 
 import com.google.common.collect.Lists;
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.async.detection.DetectionTask;
@@ -345,7 +346,7 @@ public class AsyncManager extends BukkitRunnable {
             if(Settings.Debug) {
                 Movecraft.getInstance().getLogger().info("TickCoolDown: " + tickCoolDown);
             }
-            if(pcraft.getCruiseDirection() != 0x42 && pcraft.getCruiseDirection() != 0x43) {
+            if(pcraft.getCruiseDirection() != CruiseDirection.UP && pcraft.getCruiseDirection() != CruiseDirection.DOWN) {
                 if (bankLeft || bankRight) {
                     if (!dive) {
                         tickCoolDown *= (Math.sqrt(Math.pow(1 + pcraft.getType().getCruiseSkipBlocks(w), 2) + Math.pow(pcraft.getType().getCruiseSkipBlocks(w) >> 1, 2)) / (1 + pcraft.getType().getCruiseSkipBlocks(w)));
@@ -370,11 +371,11 @@ public class AsyncManager extends BukkitRunnable {
             int dy = 0;
 
             // ascend
-            if (pcraft.getCruiseDirection() == 0x42) {
+            if (pcraft.getCruiseDirection() == CruiseDirection.UP) {
                 dy = 1 + pcraft.getType().getVertCruiseSkipBlocks();
             }
             // descend
-            if (pcraft.getCruiseDirection() == 0x43) {
+            if (pcraft.getCruiseDirection() == CruiseDirection.DOWN) {
                 dy = -1 - pcraft.getType().getVertCruiseSkipBlocks();
                 if (pcraft.getHitBox().getMinY() <= w.getSeaLevel()) {
                     dy = -1;
@@ -386,7 +387,7 @@ public class AsyncManager extends BukkitRunnable {
                 }
             }
             // ship faces west
-            if (pcraft.getCruiseDirection() == 0x5) {
+            if (pcraft.getCruiseDirection() == CruiseDirection.WEST) {
                 dx = -1 - pcraft.getType().getCruiseSkipBlocks(w);
                 if (bankRight) {
                     dz = (-1 - pcraft.getType().getCruiseSkipBlocks(w)) >> 1;
@@ -396,7 +397,7 @@ public class AsyncManager extends BukkitRunnable {
                 }
             }
             // ship faces east
-            if (pcraft.getCruiseDirection() == 0x4) {
+            if (pcraft.getCruiseDirection() == CruiseDirection.EAST) {
                 dx = 1 + pcraft.getType().getCruiseSkipBlocks(w);
                 if (bankLeft) {
                     dz = (-1 - pcraft.getType().getCruiseSkipBlocks(w)) >> 1;
@@ -406,7 +407,7 @@ public class AsyncManager extends BukkitRunnable {
                 }
             }
             // ship faces north
-            if (pcraft.getCruiseDirection() == 0x2) {
+            if (pcraft.getCruiseDirection() == CruiseDirection.SOUTH) {
                 dz = 1 + pcraft.getType().getCruiseSkipBlocks(w);
                 if (bankRight) {
                     dx = (-1 - pcraft.getType().getCruiseSkipBlocks(w)) >> 1;
@@ -416,7 +417,7 @@ public class AsyncManager extends BukkitRunnable {
                 }
             }
             // ship faces south
-            if (pcraft.getCruiseDirection() == 0x3) {
+            if (pcraft.getCruiseDirection() == CruiseDirection.NORTH) {
                 dz = -1 - pcraft.getType().getCruiseSkipBlocks(w);
                 if (bankLeft) {
                     dx = (-1 - pcraft.getType().getCruiseSkipBlocks(w)) >> 1;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -22,6 +22,7 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
@@ -216,39 +217,39 @@ public class RotationTask extends AsyncTask {
             if (rotation == Rotation.ANTICLOCKWISE) {
                 // ship faces west
                 switch (getCraft().getCruiseDirection()) {
-                    case 0x5:
-                        getCraft().setCruiseDirection((byte) 0x2);
+                    case WEST:
+                        getCraft().setCruiseDirection(CruiseDirection.SOUTH);
                         break;
                     // ship faces east
-                    case 0x4:
-                        getCraft().setCruiseDirection((byte) 0x3);
+                    case EAST:
+                        getCraft().setCruiseDirection(CruiseDirection.NORTH);
                         break;
                     // ship faces north
-                    case 0x2:
-                        getCraft().setCruiseDirection((byte) 0x4);
+                    case SOUTH:
+                        getCraft().setCruiseDirection(CruiseDirection.EAST);
                         break;
                     // ship faces south
-                    case 0x3:
-                        getCraft().setCruiseDirection((byte) 0x5);
+                    case NORTH:
+                        getCraft().setCruiseDirection(CruiseDirection.WEST);
                         break;
                 }
             } else if (rotation == Rotation.CLOCKWISE) {
                 // ship faces west
                 switch (getCraft().getCruiseDirection()) {
-                    case 0x5:
-                        getCraft().setCruiseDirection((byte) 0x3);
+                    case WEST:
+                        getCraft().setCruiseDirection(CruiseDirection.NORTH);
                         break;
                     // ship faces east
-                    case 0x4:
-                        getCraft().setCruiseDirection((byte) 0x2);
+                    case EAST:
+                        getCraft().setCruiseDirection(CruiseDirection.SOUTH);
                         break;
                     // ship faces north
-                    case 0x2:
-                        getCraft().setCruiseDirection((byte) 0x5);
+                    case SOUTH:
+                        getCraft().setCruiseDirection(CruiseDirection.WEST);
                         break;
                     // ship faces south
-                    case 0x3:
-                        getCraft().setCruiseDirection((byte) 0x4);
+                    case NORTH:
+                        getCraft().setCruiseDirection(CruiseDirection.EAST);
                         break;
                 }
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/CruiseCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/commands/CruiseCommand.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.commands;
 
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.localisation.I18nSupport;
@@ -47,13 +48,13 @@ public class CruiseCommand implements TabExecutor {
                 yaw %= 360.0f;
             }
             if (yaw >= 45 && yaw < 135) { // west
-                craft.setCruiseDirection((byte)0x5);
+                craft.setCruiseDirection(CruiseDirection.WEST);
             } else if (yaw >= 135 && yaw < 225) { // north
-                craft.setCruiseDirection((byte)0x3);
+                craft.setCruiseDirection(CruiseDirection.NORTH);
             } else if (yaw >= 225 && yaw <= 315){ // east
-                craft.setCruiseDirection((byte)0x4);
+                craft.setCruiseDirection(CruiseDirection.EAST);
             } else { // default south
-                craft.setCruiseDirection((byte)0x2);
+                craft.setCruiseDirection(CruiseDirection.SOUTH);
             }
             craft.setCruising(true);
             return true;
@@ -94,34 +95,34 @@ public class CruiseCommand implements TabExecutor {
                 yaw %= 360.0f;
             }
             if (yaw >= 45 && yaw < 135) { // west
-                craft.setCruiseDirection((byte)0x5);
+                craft.setCruiseDirection(CruiseDirection.WEST);
             } else if (yaw >= 135 && yaw < 225) { // north
-                craft.setCruiseDirection((byte)0x3);
+                craft.setCruiseDirection(CruiseDirection.NORTH);
             } else if (yaw >= 225 && yaw <= 315){ // east
-                craft.setCruiseDirection((byte)0x4);
+                craft.setCruiseDirection(CruiseDirection.EAST);
             } else { // default south
-                craft.setCruiseDirection((byte)0x2);
+                craft.setCruiseDirection(CruiseDirection.SOUTH);
             }
             craft.setCruising(true);
             return true;
         }
         if (args[0].equalsIgnoreCase("north") || args[0].equalsIgnoreCase("n")) {
-            craft.setCruiseDirection((byte) 0x3);
+            craft.setCruiseDirection(CruiseDirection.NORTH);
             craft.setCruising(true);
             return true;
         }
         if (args[0].equalsIgnoreCase("south") || args[0].equalsIgnoreCase("s")) {
-            craft.setCruiseDirection((byte) 0x2);
+            craft.setCruiseDirection(CruiseDirection.SOUTH);
             craft.setCruising(true);
             return true;
         }
         if (args[0].equalsIgnoreCase("east") || args[0].equalsIgnoreCase("e")) {
-            craft.setCruiseDirection((byte) 0x4);
+            craft.setCruiseDirection(CruiseDirection.EAST);
             craft.setCruising(true);
             return true;
         }
         if (args[0].equalsIgnoreCase("west") || args[0].equalsIgnoreCase("w")) {
-            craft.setCruiseDirection((byte) 0x5);
+            craft.setCruiseDirection(CruiseDirection.WEST);
             craft.setCruising(true);
             return true;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
@@ -54,7 +55,7 @@ public class AscendSign implements Listener {
             sign.setLine(0, "Ascend: ON");
             sign.update(true);
 
-            c.setCruiseDirection((byte) 0x42);
+            c.setCruiseDirection(CruiseDirection.UP);
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
             c.resetSigns(sign);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
@@ -66,7 +67,8 @@ public final class CraftSign implements Listener{
 
         if (c.getType().getCruiseOnPilot()) {
             c.detect(null, event.getPlayer(), startPoint);
-            c.setCruiseDirection(sign.getRawData());
+            org.bukkit.material.Sign materialSign = (org.bukkit.material.Sign) event.getClickedBlock().getState().getData();
+            c.setCruiseDirection(CruiseDirection.fromBlockFace(materialSign.getFacing()));
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
             new BukkitRunnable() {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
@@ -67,8 +67,11 @@ public final class CraftSign implements Listener{
 
         if (c.getType().getCruiseOnPilot()) {
             c.detect(null, event.getPlayer(), startPoint);
-            org.bukkit.material.Sign materialSign = (org.bukkit.material.Sign) event.getClickedBlock().getState().getData();
-            c.setCruiseDirection(CruiseDirection.fromBlockFace(materialSign.getFacing()));
+            org.bukkit.material.Sign materialSign = (org.bukkit.material.Sign) block.getState().getData();
+            if(block.getType() == Material.SIGN_POST)
+                c.setCruiseDirection(CruiseDirection.NONE);
+            else
+                c.setCruiseDirection(CruiseDirection.fromBlockFace(materialSign.getFacing()));
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
             new BukkitRunnable() {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -59,8 +59,11 @@ public final class CruiseSign implements Listener{
             sign.setLine(0, "Cruise: ON");
             sign.update(true);
 
-            org.bukkit.material.Sign materialSign = (org.bukkit.material.Sign) event.getClickedBlock().getState().getData();
-            c.setCruiseDirection(CruiseDirection.fromBlockFace(materialSign.getFacing()));
+            org.bukkit.material.Sign materialSign = (org.bukkit.material.Sign) block.getState().getData();
+            if(block.getType() == Material.SIGN_POST)
+                c.setCruiseDirection(CruiseDirection.NONE);
+            else
+                c.setCruiseDirection(CruiseDirection.fromBlockFace(materialSign.getFacing()));
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
             c.resetSigns(sign);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
@@ -58,7 +59,8 @@ public final class CruiseSign implements Listener{
             sign.setLine(0, "Cruise: ON");
             sign.update(true);
 
-            c.setCruiseDirection(sign.getRawData());
+            org.bukkit.material.Sign materialSign = (org.bukkit.material.Sign) event.getClickedBlock().getState().getData();
+            c.setCruiseDirection(CruiseDirection.fromBlockFace(materialSign.getFacing()));
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
             c.resetSigns(sign);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
@@ -53,7 +54,7 @@ public final class DescendSign implements Listener{
             sign.setLine(0, "Descend: ON");
             sign.update(true);
 
-            c.setCruiseDirection((byte) 0x43);
+            c.setCruiseDirection(CruiseDirection.DOWN);
             c.setLastCruiseUpdate(System.currentTimeMillis());
             c.setCruising(true);
             c.resetSigns(sign);

--- a/modules/api/src/main/java/net/countercraft/movecraft/CruiseDirection.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/CruiseDirection.java
@@ -3,16 +3,41 @@ package net.countercraft.movecraft;
 import org.bukkit.block.BlockFace;
 
 public enum CruiseDirection {
-    NORTH, //0x3
-    SOUTH, //0x2
-    EAST, //0x4
-    WEST, //0x5
-    UP, //0x42
-    DOWN, //0x43
-    NONE;
+    NORTH((byte) 0x3), //0x3
+    SOUTH((byte) 0x2), //0x2
+    EAST((byte) 0x4), //0x4
+    WEST((byte) 0x5), //0x5
+    UP((byte) 0x42), //0x42
+    DOWN((byte) 0x43), //0x43
+    NONE((byte) 0x0);
 
-    public static CruiseDirection fromBlockFace(BlockFace direction)
-    {
+    private final byte raw;
+
+    CruiseDirection(byte rawDirection) {
+        raw = rawDirection;
+    }
+
+    public byte getRaw() {
+        return raw;
+    }
+    public static CruiseDirection fromRaw(byte rawDirection) {
+        if(rawDirection == (byte) 0x3)
+            return NORTH;
+        else if(rawDirection == (byte) 0x2)
+            return SOUTH;
+        else if(rawDirection == (byte) 0x4)
+            return EAST;
+        else if(rawDirection == (byte) 0x5)
+            return WEST;
+        else if(rawDirection == (byte) 0x42)
+            return UP;
+        else if(rawDirection == (byte) 0x43)
+            return DOWN;
+        else
+            return NONE;
+    }
+
+    public static CruiseDirection fromBlockFace(BlockFace direction) {
         if(direction.getOppositeFace() == BlockFace.NORTH)
             return NORTH;
         else if(direction.getOppositeFace() == BlockFace.SOUTH)

--- a/modules/api/src/main/java/net/countercraft/movecraft/CruiseDirection.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/CruiseDirection.java
@@ -1,0 +1,32 @@
+package net.countercraft.movecraft;
+
+import org.bukkit.block.BlockFace;
+
+public enum CruiseDirection {
+    NORTH, //0x3
+    SOUTH, //0x2
+    EAST, //0x4
+    WEST, //0x5
+    UP, //0x42
+    DOWN, //0x43
+    NONE;
+
+    public static CruiseDirection fromBlockFace(BlockFace direction)
+    {
+        if(direction.getOppositeFace() == BlockFace.NORTH)
+            return NORTH;
+        else if(direction.getOppositeFace() == BlockFace.SOUTH)
+            return SOUTH;
+        else if(direction.getOppositeFace() == BlockFace.EAST)
+            return EAST;
+        else if(direction.getOppositeFace() == BlockFace.WEST)
+            return WEST;
+        else if(direction.getOppositeFace() == BlockFace.UP)
+            return UP;
+        else if(direction.getOppositeFace() == BlockFace.DOWN)
+            return DOWN;
+        else
+            return NONE;
+    }
+}
+

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -17,6 +17,7 @@
 
 package net.countercraft.movecraft.craft;
 
+import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
 import net.countercraft.movecraft.config.Settings;
@@ -53,7 +54,7 @@ public abstract class Craft {
     private boolean cruising;
     private boolean sinking;
     private boolean disabled;
-    private byte cruiseDirection;
+    private CruiseDirection cruiseDirection;
     private long lastCruiseUpdate;
     private long lastBlockCheck;
     private long lastRotateTime=0;
@@ -190,11 +191,11 @@ public abstract class Craft {
         this.disabled = disabled;
     }
 
-    public byte getCruiseDirection() {
+    public CruiseDirection getCruiseDirection() {
         return cruiseDirection;
     }
 
-    public void setCruiseDirection(byte cruiseDirection) {
+    public void setCruiseDirection(CruiseDirection cruiseDirection) {
         this.cruiseDirection = cruiseDirection;
     }
 
@@ -324,7 +325,7 @@ public abstract class Craft {
             return (type.getTickCooldown(w) + chestPenalty) * (type.getGearShiftsAffectTickCooldown() ? currentGear : 1);
 
         // Ascent or Descent
-        if(cruiseDirection == 0x42 || cruiseDirection == 0x43) {
+        if(cruiseDirection == CruiseDirection.UP || cruiseDirection == CruiseDirection.DOWN) {
             return (type.getVertCruiseTickCooldown(w) + chestPenalty) * (type.getGearShiftsAffectTickCooldown() ? currentGear : 1);
         }
 
@@ -363,7 +364,7 @@ public abstract class Craft {
      * @return the speed of the craft
      */
     public double getSpeed() {
-        if(cruiseDirection == 0x42 || cruiseDirection == 0x43) {
+        if(cruiseDirection == CruiseDirection.UP || cruiseDirection == CruiseDirection.DOWN) {
             return 20 * (type.getVertCruiseSkipBlocks(w) + 1) / (double) getTickCooldown();
         }
         else {


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
This PR makes the craft's cruiseDirection an Enum instead of a cryptic byte value.

### Related issues:
- fix #358 
- fix #359

### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
