### PR TITLE
Craft type parse error

### DIFF
--- a/modules/Movecraft/pom.xml
+++ b/modules/Movecraft/pom.xml
@@ -116,7 +116,6 @@
             <version>8.3.1</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/modules/Movecraft/pom.xml
+++ b/modules/Movecraft/pom.xml
@@ -116,6 +116,7 @@
             <version>8.3.1</version>
             <scope>compile</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -343,9 +343,6 @@ public class AsyncManager extends BukkitRunnable {
             }
 
             // Account for banking and diving in speed calculations by changing the tickCoolDown
-            if(Settings.Debug) {
-                Movecraft.getInstance().getLogger().info("TickCoolDown: " + tickCoolDown);
-            }
             if(pcraft.getCruiseDirection() != CruiseDirection.UP && pcraft.getCruiseDirection() != CruiseDirection.DOWN) {
                 if (bankLeft || bankRight) {
                     if (!dive) {
@@ -356,10 +353,6 @@ public class AsyncManager extends BukkitRunnable {
                 } else if (dive) {
                     tickCoolDown *= (Math.sqrt(Math.pow(1 + pcraft.getType().getCruiseSkipBlocks(w), 2) + 1) / (1 + pcraft.getType().getCruiseSkipBlocks(w)));
                 }
-            }
-            if(Settings.Debug) {
-                Movecraft.getInstance().getLogger().info("New TickCoolDown: " + tickCoolDown);
-                Movecraft.getInstance().getLogger().info("Direction:" + (bankLeft ? " Banking Left" : "") + (bankRight ? " Banking Right" : "") + (dive ? " Diving" : ""));
             }
 
             if (Math.abs(ticksElapsed) < tickCoolDown) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -24,6 +24,7 @@ import net.countercraft.movecraft.events.TypesReloadedEvent;
 import net.countercraft.movecraft.exception.NonCancellableReleaseException;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -99,7 +100,7 @@ public class CraftManager implements Iterable<Craft>{
                         craftTypes.add(type);
                     }
                     catch (CraftType.TypeNotFoundException | CraftType.TypeParseException e) {
-                        Movecraft.getInstance().getLogger().log(Level.SEVERE, ERROR_PREFIX + I18nSupport.getInternationalisedString("Startup - failure to load craft type"));
+                        Movecraft.getInstance().getLogger().log(Level.SEVERE, I18nSupport.getInternationalisedString("Startup - failure to load craft type") + " " + file.getName());
                     }
                 }
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -24,7 +24,6 @@ import net.countercraft.movecraft.events.TypesReloadedEvent;
 import net.countercraft.movecraft.exception.NonCancellableReleaseException;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -33,9 +32,9 @@ import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.scanner.ScannerException;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -99,8 +98,9 @@ public class CraftManager implements Iterable<Craft>{
                         CraftType type = new CraftType(file);
                         craftTypes.add(type);
                     }
-                    catch (CraftType.TypeNotFoundException | CraftType.TypeParseException e) {
+                    catch (CraftType.TypeNotFoundException | ScannerException e) {
                         Movecraft.getInstance().getLogger().log(Level.SEVERE, I18nSupport.getInternationalisedString("Startup - failure to load craft type") + " " + file.getName());
+                        e.printStackTrace();
                     }
                 }
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -93,8 +94,13 @@ public class CraftManager implements Iterable<Craft>{
             if (file.isFile()) {
 
                 if (file.getName().contains(".craft")) {
-                    CraftType type = new CraftType(file);
-                    craftTypes.add(type);
+                    try {
+                        CraftType type = new CraftType(file);
+                        craftTypes.add(type);
+                    }
+                    catch (CraftType.TypeNotFoundException | CraftType.TypeParseException e) {
+                        Movecraft.getInstance().getLogger().log(Level.SEVERE, ERROR_PREFIX + I18nSupport.getInternationalisedString("Startup - failure to load craft type"));
+                    }
                 }
             }
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -86,7 +86,7 @@ public class CraftManager implements Iterable<Craft>{
 
         Set<CraftType> craftTypes = new HashSet<>();
         File[] files = craftsFile.listFiles();
-        if (files == null){
+        if (files == null) {
             return craftTypes;
         }
 
@@ -99,8 +99,7 @@ public class CraftManager implements Iterable<Craft>{
                         craftTypes.add(type);
                     }
                     catch (CraftType.TypeNotFoundException | ScannerException e) {
-                        Movecraft.getInstance().getLogger().log(Level.SEVERE, I18nSupport.getInternationalisedString("Startup - failure to load craft type") + " " + file.getName());
-                        e.printStackTrace();
+                        Movecraft.getInstance().getLogger().log(Level.SEVERE, I18nSupport.getInternationalisedString("Startup - failure to load craft type") + " '" + file.getName() + "' " + e.getMessage());
                     }
                 }
             }

--- a/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
+++ b/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
@@ -116,6 +116,7 @@ Scuttle\ -\ Scuttle\ Activated=Scuttle was activated. Abandon Ship\!
 Startup\ -\ Number\ of\ craft\ files\ loaded=Loaded %d Craft files
 Startup\ -\ No\ Crafts\ Found=NO CRAFT FILES FOUND\!
 Startup\ -\ Error\ parsing\ CraftType\ file=***ERROR PARSING CRAFT FILE FROM DIRECTORY \: %s***
+Startup\ -\ failure\ to\ load\ craft\ type=ERROR PARSING CRAFT FILE\:
 Startup\ -\ Error\ -\ Reload\ error=Movecraft is incompatible with the reload command. Movecraft has shut down and will restart when the server is restarted.
 Startup\ -\ Error\ -\ Disable\ warning\ for\ reload=If you wish to use the reload command and Movecraft, you may disable this check inside the config.yml by setting 'safeReload \: false'
 Startup\ -\ Enabled\ message=[V %S] has been enabled.

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -17,14 +17,11 @@
 
 package net.countercraft.movecraft.craft;
 
-import net.countercraft.movecraft.config.Settings;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.scanner.ScannerException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -129,10 +126,6 @@ final public class CraftType {
         }
         catch (IOException e) {
             throw new TypeNotFoundException("No file found at path " + f.getAbsolutePath());
-        }
-        catch (ScannerException e) {
-            e.printStackTrace();
-            throw new TypeParseException("Unable to parse " + f.getAbsolutePath());
         }
 
         //Required craft flags
@@ -855,12 +848,6 @@ final public class CraftType {
 
     public class TypeNotFoundException extends RuntimeException {
         public TypeNotFoundException(String s) {
-            super(s);
-        }
-    }
-
-    public class TypeParseException extends RuntimeException {
-        public TypeParseException(String s) {
             super(s);
         }
     }

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -221,13 +221,6 @@ final public class CraftType {
                 perWorldVertCruiseTickCooldown.put(world, (int) Math.round((1.0 + worldVertCruiseSkipBlocks) * 20.0 / vertCruiseSpeed));
             }
         });
-        if(Settings.Debug) {
-            Bukkit.getLogger().info("Craft: " + craftName);
-            Bukkit.getLogger().info("CruiseSpeed: " + cruiseSpeed);
-            Bukkit.getLogger().info("Cooldown: " + cruiseTickCooldown);
-            Bukkit.getLogger().info("VertCruiseSpeed: " + vertCruiseSpeed);
-            Bukkit.getLogger().info("VertCooldown: " + vertCruiseTickCooldown);
-        }
 
         int value = Math.min(integerFromObject(data.getOrDefault("maxHeightLimit", 254)), 255);
         if (value <= minHeightLimit) {

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -24,6 +24,7 @@ import org.bukkit.Sound;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.scanner.ScannerException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -125,8 +126,13 @@ final public class CraftType {
             Yaml yaml = new Yaml();
             data = (Map) yaml.load(input);
             input.close();
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new TypeNotFoundException("No file found at path " + f.getAbsolutePath());
+        }
+        catch (ScannerException e) {
+            e.printStackTrace();
+            throw new TypeParseException("Unable to parse " + f.getAbsolutePath());
         }
 
         //Required craft flags
@@ -854,8 +860,14 @@ final public class CraftType {
         return gearShiftsAffectCruiseSkipBlocks;
     }
 
-    private class TypeNotFoundException extends RuntimeException {
+    public class TypeNotFoundException extends RuntimeException {
         public TypeNotFoundException(String s) {
+            super(s);
+        }
+    }
+
+    public class TypeParseException extends RuntimeException {
+        public TypeParseException(String s) {
             super(s);
         }
     }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
Currently, when a craft file fails to load correctly the server throws the exception to console and Movecraft fails to catch it, causing the entire CraftManager to be in a bad state and throwing a ton more errors.  This PR fixes that by catching the exception and printing it along with a helpful message that the craft type was not loaded.

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
