### PR TITLE
Listener priority

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -71,9 +71,6 @@ public class BlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(final BlockBreakEvent e) {
-        if (e.isCancelled()) {
-            return;
-        }
         if (e.getBlock().getType() == Material.WALL_SIGN) {
             Sign s = (Sign) e.getBlock().getState();
             if (s.getLine(0).equalsIgnoreCase(ChatColor.RED + I18nSupport.getInternationalisedString("Region Damaged"))) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -69,7 +69,7 @@ public class BlockListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(final BlockBreakEvent e) {
         if (e.isCancelled()) {
             return;


### PR DESCRIPTION
### Describe in detail what your pull request acomplishes

Custom plugins which listen to the BlockBreakEvent on the HIGHEST priority, for example to double-drop, drop custom items, or any other use-case, will still execute and create infinite dupe "bugs" due to plugins competing with Movecraft for priority.

This is the case with a custom plugin on my server, which listens to and modifies the BlockBreakEvent on HIGHEST, and then Movecraft immediately cancels the block being broken. 

My plugin can not and should not listen on MONITOR, because it modifies the BlockBreakEvent which then needs to be able to pass an accurate current state on to any MONITOR listeners.

For this reason, I have lowered Movecraft's BlockBreakEvent listener to LOWEST

This is beneficial for plugin compatibility, and is in the best interest of Movecraft

This listeners sole purpose appears to be cancelling the event in the case that the block is significant to a ship.

In this case, it has no care for the state of the block, and there's absolutely no reason why Movecraft should allow lower-priority listeners to execute logic on these ship blocks. Movecraft should want to cancel this event as soon as possible.

Secondarily, I've removed the check for "isCancelled()". 
This check was redundant both before and after my change, the default state of a listener is to ignore cancelled events.

### Checklist
- [ X ] Proper internationalization
- [ X ] Compiled/tested
