### PR TITLE
Sinking patch

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -670,6 +670,7 @@ public class AsyncManager extends BukkitRunnable {
     }
 
     //Returns a given craft's status as a CraftStatus enum.
+    @NotNull
     public CraftStatus checkCraftStatus(@NotNull Craft craft) {
         boolean isSinking = false;
         boolean isDisabled = false;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -34,12 +34,26 @@ import net.countercraft.movecraft.mapUpdater.MapUpdateManager;
 import net.countercraft.movecraft.mapUpdater.update.BlockCreateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
 import net.countercraft.movecraft.utils.*;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
@@ -454,13 +468,11 @@ public class AsyncManager extends BukkitRunnable {
                 continue;
             }
 
-            Pair<Boolean,Boolean> status = checkCraftStatus(pcraft);
-            boolean isSinking = status.getLeft();
-            boolean isDisabled = status.getRight();
+            CraftStatus status = checkCraftStatus(pcraft);
 
             //If the craft is disabled, play a sound and disable it.
             //Only do this if the craft isn't already disabled.
-            if(isDisabled && pcraft.isNotProcessing()) {
+            if(status.isDisabled() && pcraft.isNotProcessing()) {
                 if (!pcraft.getDisabled()) {
                     pcraft.setDisabled(true);
                     if (pcraft.getNotificationPlayer() != null) {
@@ -473,7 +485,7 @@ public class AsyncManager extends BukkitRunnable {
             // if the craft is sinking, let the player
             // know and release the craft. Otherwise
             // update the time for the next check
-            if (isSinking && pcraft.isNotProcessing()) {
+            if (status.isSinking() && pcraft.isNotProcessing()) {
                 Player notifyP = pcraft.getNotificationPlayer();
                 if (notifyP != null) {
                     notifyP.sendMessage(I18nSupport.getInternationalisedString("Player - Craft is sinking"));
@@ -654,7 +666,7 @@ public class AsyncManager extends BukkitRunnable {
 
     //Returns a given craft's status as a pair of booleans.
     //Left is sinking, right is disabled.
-    public Pair<Boolean, Boolean> checkCraftStatus(Craft craft) {
+    public CraftStatus checkCraftStatus(Craft craft) {
         boolean isSinking = false;
         boolean isDisabled = false;
         int totalNonNegligibleBlocks = 0;
@@ -733,7 +745,7 @@ public class AsyncManager extends BukkitRunnable {
             isSinking = true;
         }
 
-        return new Pair<>(isSinking, isDisabled);
+        return CraftStatus.fromBooleans(isSinking, isDisabled);
     }
 
     //Removed for refactor

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -33,7 +33,12 @@ import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.mapUpdater.MapUpdateManager;
 import net.countercraft.movecraft.mapUpdater.update.BlockCreateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
-import net.countercraft.movecraft.utils.*;
+import net.countercraft.movecraft.utils.BitmapHitBox;
+import net.countercraft.movecraft.utils.CollectionUtils;
+import net.countercraft.movecraft.utils.CraftStatus;
+import net.countercraft.movecraft.utils.HitBox;
+import net.countercraft.movecraft.utils.Pair;
+import net.countercraft.movecraft.utils.SolidHitBox;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -664,17 +669,16 @@ public class AsyncManager extends BukkitRunnable {
         }
     }
 
-    //Returns a given craft's status as a pair of booleans.
-    //Left is sinking, right is disabled.
-    public CraftStatus checkCraftStatus(Craft craft) {
+    //Returns a given craft's status as a CraftStatus enum.
+    public CraftStatus checkCraftStatus(@NotNull Craft craft) {
         boolean isSinking = false;
         boolean isDisabled = false;
         int totalNonNegligibleBlocks = 0;
         int totalNonNegligibleWaterBlocks = 0;
         HashMap<List<Integer>, Integer> foundFlyBlocks = new HashMap<>();
         HashMap<List<Integer>, Integer> foundMoveBlocks = new HashMap<>();
-        // go through each block in the blocklist, and
-        // if its in the FlyBlocks, total up the number
+        // go through each block in the HitBox, and
+        // if it's in the FlyBlocks, total up the number
         // of them
         for (MovecraftLocation l : craft.getHitBox()) {
             int blockID = craft.getW().getBlockAt(l.getX(), l.getY(), l.getZ()).getTypeId();
@@ -699,7 +703,7 @@ public class AsyncManager extends BukkitRunnable {
             }
         }
 
-        // now see if any of the resulting percentagesit
+        // now see if any of the resulting percentages
         // are below the threshold specified in
         // SinkPercent
 
@@ -726,7 +730,7 @@ public class AsyncManager extends BukkitRunnable {
             isDisabled = (percent < disablePercent && !craft.getDisabled() && craft.isNotProcessing());
         }
 
-        // And check the overallsinkpercent
+        // And check the OverallSinkPercent
         if (craft.getType().getOverallSinkPercent() != 0.0) {
             double percent;
             if (craft.getType().blockedByWater()) {
@@ -745,7 +749,7 @@ public class AsyncManager extends BukkitRunnable {
             isSinking = true;
         }
 
-        return CraftStatus.fromBooleans(isSinking, isDisabled);
+        return CraftStatus.of(isSinking, isDisabled);
     }
 
     //Removed for refactor

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -454,9 +454,9 @@ public class AsyncManager extends BukkitRunnable {
                 continue;
             }
 
-            Pair<Boolean,Boolean> Status = checkCraftStatus(pcraft);
-            boolean isSinking = Status.getLeft();
-            boolean isDisabled = Status.getRight();
+            Pair<Boolean,Boolean> status = checkCraftStatus(pcraft);
+            boolean isSinking = status.getLeft();
+            boolean isDisabled = status.getRight();
 
             //If the craft is disabled, play a sound and disable it.
             //Only do this if the craft isn't already disabled.

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -18,7 +18,6 @@
 package net.countercraft.movecraft.async;
 
 import com.google.common.collect.Lists;
-import net.countercraft.movecraft.CraftStatus;
 import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -328,8 +328,10 @@ public class TranslationTask extends AsyncTask {
                 if (!oldLocation.getBlock().getType().equals(Material.AIR)) {
                     CraftCollisionExplosionEvent e = new CraftCollisionExplosionEvent(craft, newLocation, craft.getW());
                     Bukkit.getServer().getPluginManager().callEvent(e);
-                    updates.add(new ExplosionUpdateCommand(newLocation, explosionForce));
-                    collisionExplosion = true;
+                    if(!e.isCancelled()) {
+                        updates.add(new ExplosionUpdateCommand(newLocation, explosionForce));
+                        collisionExplosion = true;
+                    }
                 }
                 if (craft.getType().getFocusedExplosion()) { // don't handle any further collisions if it is set to focusedexplosion
                     break;

--- a/modules/api/src/main/java/net/countercraft/movecraft/utils/CraftStatus.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/utils/CraftStatus.java
@@ -1,0 +1,30 @@
+package net.countercraft.movecraft.utils;
+
+
+public enum CraftStatus {
+    NORMAL,
+    SINKING,
+    DISABLED,
+    SINKING_DISABLED;
+
+    public boolean isSinking() {
+        return (this == SINKING || this == SINKING_DISABLED);
+    }
+
+    public boolean isDisabled() {
+        return (this == DISABLED || this == SINKING_DISABLED);
+    }
+
+    public static CraftStatus fromBooleans (boolean sinking, boolean disabled) {
+        if (!sinking && !disabled) {
+            return NORMAL;
+        }
+        if (!disabled) {
+            return SINKING;
+        }
+        if (!sinking) {
+            return DISABLED;
+        }
+        return SINKING_DISABLED;
+    }
+}

--- a/modules/api/src/main/java/net/countercraft/movecraft/utils/CraftStatus.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/utils/CraftStatus.java
@@ -15,7 +15,7 @@ public enum CraftStatus {
         return (this == DISABLED || this == SINKING_DISABLED);
     }
 
-    public static CraftStatus fromBooleans (boolean sinking, boolean disabled) {
+    public static CraftStatus of (boolean sinking, boolean disabled) {
         if (!sinking && !disabled) {
             return NORMAL;
         }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
This patch makes two changes to make a torpedo consistency improvement in MCC possible:
1. Moves the status checking in AsyncManager to a publicaly accessible method to allow checking of a craft's status at will
2. Changes the properties of CollisionExplosion crafts so that they do not explode if their CraftCollisionExplosionEvent is cancelled.

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
