### PR TITLE
[1.13+] Do not take BlockState snapshots when using Paper or its forks.

### DIFF
--- a/modules/Movecraft/pom.xml
+++ b/modules/Movecraft/pom.xml
@@ -24,6 +24,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -67,7 +71,12 @@
             <version>8.3.1</version>
             <scope>compile</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.6</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -156,6 +165,10 @@
                                     <pattern>it.unimi</pattern>
                                     <shadedPattern>net.countercraft.movecraft.libs.it.unimi</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.papermc.lib</pattern>
+                                    <shadedPattern>net.countercraft.movecraft.libs.paperlib</shadedPattern>
+                                </relocation>
                             </relocations>
                             <minimizeJar>true</minimizeJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
@@ -186,6 +199,7 @@
                                     <include>it.unimi.dsi:fastutil*</include>
                                     <include>net.kyori:adventure*</include>
                                     <include>net.kyori:examination*</include>
+                                    <include>io.papermc:paperlib:jar:*</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -17,6 +17,7 @@
 
 package net.countercraft.movecraft;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.async.AsyncManager;
 import net.countercraft.movecraft.commands.ContactsCommand;
 import net.countercraft.movecraft.commands.CraftReportCommand;
@@ -254,6 +255,10 @@ public class Movecraft extends JavaPlugin {
             logger.log(Level.INFO, String.format(
                     I18nSupport.getInternationalisedString("Startup - Enabled message"),
                     getDescription().getVersion()));
+
+            if (PaperLib.isSpigot()) {
+                PaperLib.suggestPaper(this);
+            }
         }
     }
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncTask.java
@@ -17,6 +17,7 @@
 
 package net.countercraft.movecraft.async;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
@@ -77,7 +78,7 @@ public abstract class AsyncTask extends BukkitRunnable {
         for (MovecraftLocation bTest : craft.getHitBox()) {
             Block b = craft.getWorld().getBlockAt(bTest.getX(), bTest.getY(), bTest.getZ());
             if (b.getType() == Material.FURNACE) {
-                InventoryHolder inventoryHolder = (InventoryHolder) b.getState();
+                InventoryHolder inventoryHolder = (InventoryHolder) PaperLib.getBlockState(b, false).getState();
                 for (ItemStack stack : inventoryHolder.getInventory()) {
                     if (stack == null || !craft.getType().getFuelTypes().containsKey(stack.getType()))
                         continue;
@@ -89,7 +90,7 @@ public abstract class AsyncTask extends BukkitRunnable {
         if (fuelHolder == null) {
             return false;
         }
-        InventoryHolder inventoryHolder = (InventoryHolder) fuelHolder.getState();
+        InventoryHolder inventoryHolder = (InventoryHolder) PaperLib.getBlockState(fuelHolder, false).getState();
         for (ItemStack iStack : inventoryHolder.getInventory()) {
             if (iStack == null)
                 continue;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.async.translation;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftChunk;
 import net.countercraft.movecraft.MovecraftLocation;
@@ -35,6 +36,7 @@ import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
@@ -488,11 +490,12 @@ public class TranslationTask extends AsyncTask {
                 }
             }
             //get contents of inventories before deposting
-            if (block.getState() instanceof InventoryHolder) {
-                if (block.getState() instanceof Chest) {
-                    drops.addAll(Arrays.asList(((Chest) block.getState()).getBlockInventory().getContents()));
+            BlockState state = PaperLib.getBlockState(block, false).getState();
+            if (state instanceof InventoryHolder) {
+                if (state instanceof Chest) {
+                    drops.addAll(Arrays.asList(((Chest) state).getBlockInventory().getContents()));
                 } else {
-                    drops.addAll(Arrays.asList((((InventoryHolder) block.getState()).getInventory().getContents())));
+                    drops.addAll(Arrays.asList((((InventoryHolder) state).getInventory().getContents())));
                 }
             }
             //call event

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.craft;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
@@ -25,6 +26,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
@@ -204,10 +206,11 @@ public abstract class BaseCraft implements Craft{
     public void resetSigns(@NotNull Sign clicked) {
         for (final MovecraftLocation ml : hitBox) {
             final Block b = ml.toBukkit(w).getBlock();
-            if (!(b.getState() instanceof Sign)) {
+            BlockState state = PaperLib.getBlockState(b, false).getState();
+            if (!(state instanceof Sign)) {
                 continue;
             }
-            final Sign sign = (Sign) b.getState();
+            final Sign sign = (Sign) state;
             if (sign.equals(clicked)) {
                 continue;
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -17,6 +17,7 @@
 
 package net.countercraft.movecraft.listener;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
@@ -26,10 +27,7 @@ import net.countercraft.movecraft.util.MathUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.block.Hopper;
-import org.bukkit.block.Sign;
+import org.bukkit.block.*;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -54,17 +52,19 @@ public class BlockListener implements Listener {
         if (e.isCancelled()) {
             return;
         }
-        if (e.getBlock().getState() instanceof Sign) {
-            Sign s = (Sign) e.getBlock().getState();
+        Block block = e.getBlock();
+        BlockState state = PaperLib.getBlockState(block, false).getState();
+        if (state instanceof Sign) {
+            Sign s = (Sign) state;
             if (s.getLine(0).equalsIgnoreCase(ChatColor.RED + I18nSupport.getInternationalisedString("Region Damaged"))) {
                 e.setCancelled(true);
                 return;
             }
         }
         if (Settings.ProtectPilotedCrafts) {
-            MovecraftLocation mloc = MathUtils.bukkit2MovecraftLoc(e.getBlock().getLocation());
-            CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld());
-            for (Craft craft : CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld())) {
+            MovecraftLocation mloc = MathUtils.bukkit2MovecraftLoc(block.getLocation());
+            CraftManager.getInstance().getCraftsInWorld(block.getWorld());
+            for (Craft craft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
                 if (craft == null || craft.getDisabled()) {
                     continue;
                 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/BlockCreateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/BlockCreateCommand.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.mapUpdater.update;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
@@ -44,7 +45,7 @@ public class BlockCreateCommand extends UpdateCommand {
         // now do the block updates, move entities when you set the block they are on
         Movecraft.getInstance().getWorldHandler().setBlockFast(newBlockLocation.toBukkit(world), data);
         //craft.incrementBlockUpdates();
-        newBlockLocation.toBukkit(world).getBlock().getState().update(false, false);
+        PaperLib.getBlockState(newBlockLocation.toBukkit(world).getBlock(), false).getState().update(false, false);
 
         //Do comperator stuff
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.mapUpdater.update;
 
+import io.papermc.lib.PaperLib;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
@@ -212,9 +213,9 @@ public class CraftRotateCommand extends UpdateCommand {
 
         for (MovecraftLocation location : craft.getHitBox()) {
             Block block = location.toBukkit(craft.getWorld()).getBlock();
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if (state instanceof Sign) {
-                Sign sign = (Sign) block.getState();
+                Sign sign = (Sign) state;
                 if(!signs.containsKey(sign.getLines()))
                     signs.put(sign.getLines(), new ArrayList<>());
                 signs.get(sign.getLines()).add(location);
@@ -229,7 +230,7 @@ public class CraftRotateCommand extends UpdateCommand {
             }
             for(MovecraftLocation location : entry.getValue()){
                 Block block = location.toBukkit(craft.getWorld()).getBlock();
-                BlockState state =  block.getState();
+                BlockState state = PaperLib.getBlockState(block, false).getState();
                 if (!(state instanceof Sign)) {
                     continue;
                 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -2,6 +2,7 @@ package net.countercraft.movecraft.mapUpdater.update;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.papermc.lib.PaperLib;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
@@ -313,7 +314,7 @@ public class CraftTranslateCommand extends UpdateCommand {
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if (state instanceof Sign) {
                 Sign sign = (Sign) state;
                 if(!signs.containsKey(sign.getLines()))
@@ -330,7 +331,7 @@ public class CraftTranslateCommand extends UpdateCommand {
             }
             for(MovecraftLocation location : entry.getValue()){
                 Block block = location.toBukkit(craft.getWorld()).getBlock();
-                BlockState state = block.getState();
+                BlockState state = PaperLib.getBlockState(block, false).getState();
                 if (!(state instanceof Sign)) {
                     continue;
                 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
@@ -26,9 +27,9 @@ public class AscendSign implements Listener {
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
-            if(block.getState() instanceof Sign){
-                Sign sign = (Sign) block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
+            if (state instanceof Sign){
+                Sign sign = (Sign) state;
                 if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")) {
                     sign.setLine(0, "Ascend: OFF");
                     sign.update();
@@ -44,10 +45,14 @@ public class AscendSign implements Listener {
             return;
         }
         Block block = event.getClickedBlock();
-        if (!(block.getState() instanceof Sign)){
+        if (!Tag.SIGNS.isTagged(block.getType())) {
             return;
         }
-        Sign sign = (Sign) event.getClickedBlock().getState();
+        BlockState state = PaperLib.getBlockState(block, false).getState();
+        if (!(state instanceof Sign)){
+            return;
+        }
+        Sign sign = (Sign) state;
         if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: OFF")) {
             if (CraftManager.getInstance().getCraftByPlayer(event.getPlayer()) == null) {
                 return;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ContactsSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ContactsSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.events.CraftDetectEvent;
@@ -22,8 +23,8 @@ public class ContactsSign implements Listener{
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
-            if(state instanceof Sign){
+            BlockState state = PaperLib.getBlockState(block, false).getState();
+            if (state instanceof Sign){
                 Sign sign = (Sign) state;
                 if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Contacts:")) {
                     sign.setLine(1, "");

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
@@ -14,6 +15,7 @@ import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.type.WallSign;
@@ -46,7 +48,10 @@ public final class CraftSign implements Listener{
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
@@ -31,7 +32,7 @@ public final class CruiseSign implements Listener{
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
                 if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: ON")) {
@@ -47,7 +48,10 @@ public final class CruiseSign implements Listener{
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
@@ -25,7 +26,7 @@ public final class DescendSign implements Listener{
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
                 if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")) {
@@ -41,7 +42,10 @@ public final class DescendSign implements Listener{
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/HelmSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/HelmSign.java
@@ -1,11 +1,13 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.Rotation;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.util.MathUtils;
 import org.bukkit.ChatColor;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
@@ -36,7 +38,10 @@ public final class HelmSign implements Listener {
         }else{
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/MoveSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/MoveSign.java
@@ -1,8 +1,10 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
@@ -18,7 +20,10 @@ public final class MoveSign implements Listener{
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/NameSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/NameSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
@@ -35,7 +36,7 @@ public final class NameSign implements Listener {
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if (!(state instanceof Sign)) {
                 return;
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RelativeMoveSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RelativeMoveSign.java
@@ -1,9 +1,11 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -19,10 +21,11 @@ public final class RelativeMoveSign implements Listener{
             return;
         }
         Block block = event.getClickedBlock();
-        if (!(block.getState() instanceof Sign)) {
+        BlockState state = PaperLib.getBlockState(block, false).getState();
+        if (!(state instanceof Sign)) {
             return;
         }
-        Sign sign = (Sign) event.getClickedBlock().getState();
+        Sign sign = (Sign) state;
         if (!ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(HEADER)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ReleaseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ReleaseSign.java
@@ -1,9 +1,11 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
 import org.bukkit.ChatColor;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
@@ -19,7 +21,10 @@ public final class ReleaseSign implements Listener{
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RemoteSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RemoteSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
@@ -9,6 +10,7 @@ import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.util.MathUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -44,7 +46,10 @@ public final class RemoteSign implements Listener{
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.LEFT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }
@@ -86,7 +91,7 @@ public final class RemoteSign implements Listener{
         LinkedList<MovecraftLocation> foundLocations = new LinkedList<MovecraftLocation>();
         boolean firstError = true;
         for (MovecraftLocation tloc : foundCraft.getHitBox()) {
-            BlockState tstate = event.getClickedBlock().getWorld().getBlockAt(tloc.getX(), tloc.getY(), tloc.getZ()).getState();
+            BlockState tstate = PaperLib.getBlockState(event.getClickedBlock().getWorld().getBlockAt(tloc.getX(), tloc.getY(), tloc.getZ()), false).getState();
             if (!(tstate instanceof Sign)) {
                 continue;
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SpeedSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SpeedSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.events.CraftDetectEvent;
@@ -21,7 +22,7 @@ public final class SpeedSign implements Listener{
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
                 if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Speed:")) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.events.CraftDetectEvent;
@@ -29,7 +30,7 @@ public final class StatusSign implements Listener{
             if(!Tag.SIGNS.isTagged(block.getType())){
                 continue;
             }
-            BlockState state = block.getState();
+            BlockState state = PaperLib.getBlockState(block, false).getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
                 if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Status:")) {
@@ -56,7 +57,7 @@ public final class StatusSign implements Listener{
             foundBlocks.add(blockID);
 
             if (blockID == Material.FURNACE) {
-                InventoryHolder inventoryHolder = (InventoryHolder) craft.getWorld().getBlockAt(ml.getX(), ml.getY(), ml.getZ()).getState();
+                InventoryHolder inventoryHolder = (InventoryHolder) PaperLib.getBlockState(craft.getWorld().getBlockAt(ml.getX(), ml.getY(), ml.getZ()), false).getState();
                 Map<Material, Double> fuelTypes = craft.getType().getFuelTypes();
                 for (ItemStack iStack : inventoryHolder.getInventory()) {
                     if (iStack == null || !fuelTypes.containsKey(iStack.getType())) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SubcraftRotateSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SubcraftRotateSign.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.Rotation;
@@ -13,6 +14,7 @@ import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
@@ -37,7 +39,7 @@ public final class SubcraftRotateSign implements Listener {
         }else{
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/TeleportSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/TeleportSign.java
@@ -1,10 +1,12 @@
 package net.countercraft.movecraft.sign;
 
+import io.papermc.lib.PaperLib;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -20,7 +22,10 @@ public final class TeleportSign implements Listener {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
-        BlockState state = event.getClickedBlock().getState();
+        if (!Tag.SIGNS.isTagged(event.getClickedBlock().getType())) {
+            return;
+        }
+        BlockState state = PaperLib.getBlockState(event.getClickedBlock(), false).getState();
         if (!(state instanceof Sign)) {
             return;
         }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes

In 1.13+, Spigot takes snapshots of tile entities when fetching their `BlockState`. This is a relatively expensive process and is not necessary - as far as I understand - for any of the actions performed by Movecraft.

Paper allows this behaviour to be avoided. By using [PaperLib](https://github.com/PaperMC/PaperLib), we can take advantage of this while maintaining compatibility with Spigot servers. 

I did some quick testing on a local server (Purpur 1.16.5, Build 1065) using the latest alpha. The test craft consisted of 2040 standing oak signs with no text. Passthrough was enabled. The speed values were pulled from `/craftreport`:

* Without PR: 230ms
* With PR: 40ms

 This is an extreme scenario but illustrates the performance improvement quite well.


### Checklist
- [x] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested (*briefly*)
