### PR TITLE
Split off CruiseOnPilot Crafts

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CruiseOnPilotCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/CruiseOnPilotCraft.java
@@ -1,0 +1,11 @@
+package net.countercraft.movecraft.craft;
+
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+
+public class CruiseOnPilotCraft extends BaseCraft {
+
+    public CruiseOnPilotCraft(@NotNull CraftType type, @NotNull World world) {
+        super(type, world);
+    }
+}

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CraftSign.java
@@ -4,9 +4,11 @@ import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
+import net.countercraft.movecraft.craft.BaseCraft;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.craft.CraftType;
+import net.countercraft.movecraft.craft.CruiseOnPilotCraft;
 import net.countercraft.movecraft.craft.PilotedCraft;
 import net.countercraft.movecraft.events.CraftPilotEvent;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
@@ -63,10 +65,10 @@ public final class CraftSign implements Listener{
         // Attempt to run detection
         Location loc = event.getClickedBlock().getLocation();
         MovecraftLocation startPoint = new MovecraftLocation(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-        final PilotedCraft c = new PilotedCraft(type, loc.getWorld(), event.getPlayer());
-
-        if (c.getType().getCruiseOnPilot()) {
-            c.detect(null, event.getPlayer(), startPoint);
+        final BaseCraft c;
+        if (type.getCruiseOnPilot()) {
+            c = new CruiseOnPilotCraft(type, loc.getWorld());
+            c.detect(event.getPlayer(), event.getPlayer(), startPoint);
             if(sign.getBlockData() instanceof WallSign) {
                 c.setCruiseDirection(CruiseDirection.fromBlockFace(((WallSign) sign.getBlockData()).getFacing()));
             } else {
@@ -83,6 +85,7 @@ public final class CraftSign implements Listener{
                 }
             }.runTaskLater(Movecraft.getInstance(), (20 * 15));
         } else {
+            c = new PilotedCraft(type, loc.getWorld(), event.getPlayer());
             if (CraftManager.getInstance().getCraftByPlayer(event.getPlayer()) == null) {
                 c.detect(event.getPlayer(), event.getPlayer(), startPoint);
             } else {


### PR DESCRIPTION
This PR splits off CruiseOnPilot crafts into their own class, due to their unique functionality. This is a duplicate of #418 after I made a mistake regarding merging.

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
- Resolves #415 
- Resolves #414 
- Resolves #408 

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
