### PR TITLE
Convert dynamicFlyBlock to a taggable set of materials

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -32,10 +32,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -386,10 +383,13 @@ public abstract class BaseCraft implements Craft{
 
         // Dynamic Fly Block Speed
         if(type.getDynamicFlyBlockSpeedFactor() != 0){
-            Material flyBlockMaterial = type.getDynamicFlyBlock();
-            double count = materials.get(flyBlockMaterial);
-            double woolRatio = count / hitBox.size();
-            return Math.max((int)Math.round((20.0 * (type.getCruiseSkipBlocks(w) + 1)) / ((type.getDynamicFlyBlockSpeedFactor() * 1.5) * (woolRatio - .5) + (20.0 / (type.getCruiseTickCooldown(w) )) + 1)) * (type.getGearShiftsAffectTickCooldown() ? currentGear : 1), 1);
+            EnumSet<Material> flyBlockMaterials = type.getDynamicFlyBlocks();
+            double count = 0;
+            for(Material m : flyBlockMaterials) {
+                count += materials.get(m);
+            }
+            double ratio = count / hitBox.size();
+            return Math.max((int)Math.round((20.0 * (type.getCruiseSkipBlocks(w) + 1)) / ((type.getDynamicFlyBlockSpeedFactor() * 1.5) * (ratio - .5) + (20.0 / (type.getCruiseTickCooldown(w) )) + 1)) * (type.getGearShiftsAffectTickCooldown() ? currentGear : 1), 1);
         }
 
         if(type.getDynamicLagSpeedFactor() == 0.0 || type.getDynamicLagPowerFactor() == 0.0 || Math.abs(type.getDynamicLagPowerFactor()) > 1.0)

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -32,7 +32,11 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -85,7 +85,7 @@ final public class CraftType {
     private final int releaseTimeout;
     @NotNull private final Map<String, Integer> perWorldTickCooldown; // speed setting
     private final int hoverLimit;
-    private final Material dynamicFlyBlock;
+    private final EnumSet<Material> dynamicFlyBlocks;
     private final double fuelBurnRate;
     @NotNull private final Map<String, Double> perWorldFuelBurnRate;
     private final double sinkPercent;
@@ -251,7 +251,7 @@ final public class CraftType {
         dynamicLagPowerFactor = data.getDoubleOrDefault("dynamicLagPowerFactor", 0d);
         dynamicLagMinSpeed = data.getDoubleOrDefault("dynamicLagMinSpeed", 0d);
         dynamicFlyBlockSpeedFactor = data.getDoubleOrDefault("dynamicFlyBlockSpeedFactor", 0d);
-        dynamicFlyBlock = data.getMaterialOrDefault("dynamicFlyBlock", null);
+        dynamicFlyBlocks = data.getMaterialsOrEmpty("dynamicFlyBlock");
         chestPenalty = data.getDoubleOrDefault("chestPenalty", 0);
         gravityInclineDistance = data.getIntOrDefault("gravityInclineDistance", -1);
         int dropdist = data.getIntOrDefault("gravityDropDistance", -8);
@@ -677,8 +677,8 @@ final public class CraftType {
         return dynamicFlyBlockSpeedFactor;
     }
 
-    public Material getDynamicFlyBlock() {
-        return dynamicFlyBlock;
+    public EnumSet<Material> getDynamicFlyBlocks() {
+        return dynamicFlyBlocks;
     }
 
     public double getChestPenalty() {


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
Currently dynamicFlyBlock is only a single material and does not allow tagging or a list of materials (such as #wool).  This PR changes it to a set of materials.  I did not change the craft type key from `dynamicFlyBlock` to `dynamicFlyBlocks` but it is changed in code.

### Related issues:
- Fixes #440 

### Checklist
- [x] Tested
