### PR TITLE
Limit Material#createBlockData calls

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -392,6 +392,7 @@ public class AsyncManager extends BukkitRunnable {
             return;
         }
         List<HitBox> processed = new ArrayList<>();
+        BlockData airBlockData = Material.AIR.createBlockData();
         for(Map.Entry<HitBox, Long> entry : wrecks.entrySet()){
             if (Settings.FadeWrecksAfter * 1000 > System.currentTimeMillis() - entry.getValue()) {
                 continue;
@@ -420,7 +421,7 @@ public class AsyncManager extends BukkitRunnable {
                 }
                 fadedBlocks++;
                 processedFadeLocs.get(world).add(location);
-                BlockData phaseBlock = phaseBlocks.getOrDefault(bLoc, Material.AIR.createBlockData());
+                BlockData phaseBlock = phaseBlocks.getOrDefault(bLoc, airBlockData);
                 commands.add(new BlockCreateCommand(world, location, phaseBlock));
                 
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -389,8 +389,9 @@ public class TranslationTask extends AsyncTask {
 
         if(!collisionBox.isEmpty() && craft.getType().getCruiseOnPilot()){
             CraftManager.getInstance().removeCraft(craft, CraftReleaseEvent.Reason.EMPTY);
+            BlockData airBlockData = Material.AIR.createBlockData();
             for(MovecraftLocation location : oldHitBox){
-                BlockData phaseBlock = craft.getPhaseBlocks().getOrDefault(location.toBukkit(craft.getWorld()), Material.AIR.createBlockData());
+                BlockData phaseBlock = craft.getPhaseBlocks().getOrDefault(location.toBukkit(craft.getWorld()), airBlockData);
                 updates.add(new BlockCreateCommand(craft.getWorld(), location, phaseBlock));
             }
             newHitBox = new SetHitBox();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -24,6 +24,7 @@ import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -172,12 +173,13 @@ public class CraftRotateCommand extends UpdateCommand {
                 }
             }
 
+            BlockData airBlockData = Material.AIR.createBlockData();
             for (MovecraftLocation location : interior) {
                 Location bukkit = location.toBukkit(craft.getWorld());
                 var data = bukkit.getBlock().getBlockData();
                 if (passthroughBlocks.contains(data.getMaterial())) {
                     craft.getPhaseBlocks().put(bukkit, data);
-                    handler.setBlockFast(bukkit, Material.AIR.createBlockData());
+                    handler.setBlockFast(bukkit, airBlockData);
 
                 }
             }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -25,6 +25,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.jetbrains.annotations.NotNull;
 
@@ -176,12 +177,13 @@ public class CraftTranslateCommand extends UpdateCommand {
                 }
             }
 
+            BlockData airBlockData = Material.AIR.createBlockData();
             for (MovecraftLocation location : failed) {
                 Location bukkit = location.toBukkit(oldWorld);
                 var data = bukkit.getBlock().getBlockData();
                 if (passthroughBlocks.contains(data.getMaterial())) {
                     craft.getPhaseBlocks().put(bukkit, data);
-                    handler.setBlockFast(bukkit, Material.AIR.createBlockData());
+                    handler.setBlockFast(bukkit, airBlockData);
 
                 }
             }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
There are several instances where `Material#createBlockData` is called on `Material.AIR` inside a loop, but as this merely creates a `BlockData` instance with "properties initialized to unspecified defaults", it is sufficient to assign this to a variable and use that instead of creating a new instance on each iteration. I noticed this method featured quite prominently on profiling reports when using crafts with passthrough blocks enabled, so this should be a nice performance booster for them.


<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
N/A

### Checklist
- [ ] Proper internationalization (N/A)
- [x] Compiled/tested
