### PR TITLE
Improve block listeners

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -43,18 +43,23 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.material.Attachable;
 
 import java.util.EnumSet;
 
 public class BlockListener implements Listener {
+    private static final EnumSet<Material> fragileMaterials = EnumSet.of(Material.PISTON_HEAD, Material.TORCH, Material.REDSTONE_WIRE, Material.LADDER);
+    static {
+        fragileMaterials.addAll(Tag.DOORS.getValues());
+        fragileMaterials.addAll(Tag.CARPETS.getValues());
+        fragileMaterials.addAll(Tag.RAILS.getValues());
+        fragileMaterials.addAll(Tag.WOODEN_PRESSURE_PLATES.getValues());
+    }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockBreak(final BlockBreakEvent e) {
-        if (e.isCancelled()) {
-            return;
-        }
-        if (e.getBlock().getState() instanceof Sign) {
+        if (Tag.SIGNS.isTagged(e.getBlock().getType()) && e.getBlock().getState() instanceof Sign) {
             Sign s = (Sign) e.getBlock().getState();
             if (s.getLine(0).equalsIgnoreCase(ChatColor.RED + I18nSupport.getInternationalisedString("Region Damaged"))) {
                 e.setCancelled(true);
@@ -63,30 +68,24 @@ public class BlockListener implements Listener {
         }
         if (Settings.ProtectPilotedCrafts) {
             MovecraftLocation mloc = MathUtils.bukkit2MovecraftLoc(e.getBlock().getLocation());
-            CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld());
             for (Craft craft : CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld())) {
                 if (craft == null || craft.getDisabled()) {
                     continue;
                 }
-                for (MovecraftLocation tloc : craft.getHitBox()) {
-                    if (tloc.equals(mloc)) {
-                        e.getPlayer().sendMessage(I18nSupport.getInternationalisedString("Player - Block part of piloted craft"));
-                        e.setCancelled(true);
-                        return;
-                    }
+                if (craft.getHitBox().contains(mloc)) {
+                    e.getPlayer().sendMessage(I18nSupport.getInternationalisedString("Player - Block part of piloted craft"));
+                    e.setCancelled(true);
+                    return;
                 }
             }
         }
     }
 
     // prevent items from dropping from moving crafts
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemSpawn(final ItemSpawnEvent e) {
-        if (e.isCancelled()) {
-            return;
-        }
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(e.getLocation().getWorld())) {
-            if ((!tcraft.isNotProcessing()) && MathUtils.locationInHitBox(tcraft.getHitBox(), e.getLocation())) {
+            if (!tcraft.isNotProcessing() && MathUtils.locationInHitBox(tcraft.getHitBox(), e.getLocation())) {
                 e.setCancelled(true);
                 return;
             }
@@ -94,17 +93,14 @@ public class BlockListener implements Listener {
     }
 
     // prevent water and lava from spreading on moving crafts
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockFromTo(BlockFromToEvent e) {
-        if (e.isCancelled()) {
-            return;
-        }
         Block block = e.getToBlock();
-        if (block.getType() != Material.WATER && block.getType() != Material.LAVA) {
+        if (!block.isLiquid()) {
             return;
         }
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
-            if ((!tcraft.isNotProcessing()) && MathUtils.locIsNearCraftFast(tcraft, MathUtils.bukkit2MovecraftLoc(block.getLocation()))) {
+            if (!tcraft.isNotProcessing() && MathUtils.locIsNearCraftFast(tcraft, MathUtils.bukkit2MovecraftLoc(block.getLocation()))) {
                 e.setCancelled(true);
                 return;
             }
@@ -115,13 +111,9 @@ public class BlockListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onRedstoneEvent(BlockRedstoneEvent event) {
         Block block = event.getBlock();
-        CraftManager.getInstance().getCraftsInWorld(block.getWorld());
+        MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
-            MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
-            if (MathUtils.locIsNearCraftFast(tcraft, mloc) &&
-                    tcraft.getCruising() && (block.getType() == Material.STICKY_PISTON ||
-                    block.getType() == Material.PISTON || block.getType() == Material.DISPENSER &&
-                    !tcraft.isNotProcessing())) {
+            if (tcraft.getCruising() && !tcraft.isNotProcessing() && MathUtils.locIsNearCraftFast(tcraft, mloc) && block.getType() == Material.DISPENSER) {
                 event.setNewCurrent(event.getOldCurrent()); // don't allow piston movement on cruising crafts
                 return;
             }
@@ -132,10 +124,9 @@ public class BlockListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPistonEvent(BlockPistonExtendEvent event) {
         Block block = event.getBlock();
-        CraftManager.getInstance().getCraftsInWorld(block.getWorld());
+        MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
-            MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
-            if (MathUtils.locIsNearCraftFast(tcraft, mloc) && tcraft.getCruising() && !tcraft.isNotProcessing()) {
+            if (tcraft.getCruising() && !tcraft.isNotProcessing() && MathUtils.locIsNearCraftFast(tcraft, mloc)) {
                 event.setCancelled(true);
                 return;
             }
@@ -143,16 +134,16 @@ public class BlockListener implements Listener {
     }
 
     // prevent hoppers on cruising crafts
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onHopperEvent(InventoryMoveItemEvent event) {
-        if (!(event.getSource().getHolder() instanceof Hopper)) {
+        InventoryHolder holder = event.getSource().getHolder();
+        if (!(holder instanceof Hopper)) {
             return;
         }
-        Hopper block = (Hopper) event.getSource().getHolder();
-        CraftManager.getInstance().getCraftsInWorld(block.getWorld());
+        Hopper block = (Hopper) holder;
+        MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
-            MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
-            if (MathUtils.locIsNearCraftFast(tcraft, mloc) && tcraft.getCruising() && !tcraft.isNotProcessing()) {
+            if (tcraft.getCruising() && !tcraft.isNotProcessing() && MathUtils.locIsNearCraftFast(tcraft, mloc)) {
                 event.setCancelled(true);
                 return;
             }
@@ -160,37 +151,22 @@ public class BlockListener implements Listener {
     }
 
     // prevent fragile items from dropping on cruising crafts
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPhysics(BlockPhysicsEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
-
         Block block = event.getBlock();
-
-//        final int[] fragileBlocks = new int[]{26, 34, 50, 55, 63, 64, 65, 68, 69, 70, 71, 72, 75, 76, 77, 93, 94, 96, 131, 132, 143, 147, 148, 149, 150, 151, 171, 193, 194, 195, 196, 197};
-        final EnumSet<Material> fragileMaterials = EnumSet.of(Material.PISTON_HEAD, Material.TORCH, Material.REDSTONE_WIRE, Material.LADDER);
-        fragileMaterials.addAll(Tag.DOORS.getValues());
-        fragileMaterials.addAll(Tag.CARPETS.getValues());
-        fragileMaterials.addAll(Tag.RAILS.getValues());
-        fragileMaterials.addAll(Tag.WOODEN_PRESSURE_PLATES.getValues());
-        CraftManager.getInstance().getCraftsInWorld(block.getWorld());
+        MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
-            MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
             if (!MathUtils.locIsNearCraftFast(tcraft, mloc)) {
                 continue;
             }
             if (fragileMaterials.contains(event.getBlock().getType())) {
                 BlockData m = block.getBlockData();
                 BlockFace face = BlockFace.DOWN;
-                boolean faceAlwaysDown = false;
-                if (block.getType() == Material.COMPARATOR || block.getType() == Material.REPEATER)
-                    faceAlwaysDown = true;
+                boolean faceAlwaysDown = block.getType() == Material.COMPARATOR || block.getType() == Material.REPEATER;
                 if (m instanceof Attachable && !faceAlwaysDown) {
                     face = ((Attachable) m).getAttachedFace();
                 }
                 if (!event.getBlock().getRelative(face).getType().isSolid()) {
-//						if(event.getEventName().equals("BlockPhysicsEvent")) {
                     event.setCancelled(true);
                     return;
                 }
@@ -199,9 +175,8 @@ public class BlockListener implements Listener {
     }
 
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockDispense(BlockDispenseEvent e) {
-        CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld());
         for (Craft craft : CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld())) {
             if (craft != null &&
                     !craft.isNotProcessing() &&
@@ -212,7 +187,7 @@ public class BlockListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onFlow(BlockFromToEvent e){
         if(Settings.DisableSpillProtection)
             return;
@@ -221,16 +196,16 @@ public class BlockListener implements Listener {
         MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(e.getBlock().getLocation());
         MovecraftLocation toLoc = MathUtils.bukkit2MovecraftLoc(e.getToBlock().getLocation());
         for(Craft craft : CraftManager.getInstance().getCraftsInWorld(e.getBlock().getWorld())){
-            if(craft.getHitBox().contains((loc)) && !craft.getFluidLocations().contains(toLoc)) {
+            if(craft.getHitBox().contains(loc) && !craft.getFluidLocations().contains(toLoc)) {
                 e.setCancelled(true);
                 break;
             }
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onIceForm(BlockFormEvent e) {
-        if (e.isCancelled() || !Settings.DisableIceForm) {
+        if (!Settings.DisableIceForm) {
             return;
         }
         if(e.getBlock().getType() != Material.WATER)


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes

This PR cleans up parts of the `BlockListener` class and improves the performance of some of the listeners in the process

BlockBreakEvent
- Check whether the block is a sign before checking its state (although I think this should really be moved to Movecraft-Warfare)
- Remove `CraftManager#getCraftsInWorld` call that didn't do anything
- Use `HitBox#contains` to check whether the block is inside a craft's hitbox. Previously, a `MovecraftLocation` was being created for each location in every craft's hitbox.

BlockRedstoneEvent
- Remove `CraftManager#getCraftsInWorld` call that didn't do anything
- Construct `mloc` outside the loop
- Piston movement prevention is already handled by the `BlockPistonExtendEvent` listener, so I removed it from here
- Reorder conditions in the loop so the least expensive checks are performed first

BlockPistonExtendEvent
- Remove `CraftManager#getCraftsInWorld` call that didn't do anything
- Construct `mloc` outside the loop
- Reorder conditions in the loop so the least expensive checks are performed first

InventoryMoveItemEvent
- Ignore cancelled events
- Remove `CraftManager#getCraftsInWorld` call that didn't do anything
- Reorder conditions in the loop so the least expensive checks are performed first

BlockPhysicsEvent
- Declare `fragileMaterials` as a static variable and add the other materials when the class initialises.
  - Previously, `fragileMaterials` was remade every time `BlockPhysicsEvent` was called. The frequency at which occurs, however, meant this incurred considerable overhead.
- Remove `CraftManager#getCraftsInWorld` call that didn't do anything
- Construct `mloc` outside the loop

BlockDispenseEvent
- Ignore cancelled events
- Remove `CraftManager#getCraftsInWorld` call that didn't do anything

BlockFromToEvent
- Ignore cancelled events

BlockFormEvent 
- Ignore cancelled events

### Checklist
- [ ] Proper internationalization
- [x] Compiled/tested
