### PR TITLE
Allow harvested blocks to be deposited into barrels

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -471,7 +471,7 @@ public class TranslationTask extends AsyncTask {
         //find chests
         for (MovecraftLocation loc : oldHitBox) {
             Block block = craft.getWorld().getBlockAt(loc.getX(), loc.getY(), loc.getZ());
-            if (block.getType() == Material.CHEST || block.getType() == Material.TRAPPED_CHEST)
+            if (block.getType() == Material.CHEST || block.getType() == Material.TRAPPED_CHEST || block.getType() == Material.BARREL)
                 chests.add(((InventoryHolder) (block.getState())).getInventory());
         }
 


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes
This PR allows harvested blocks to be deposited into a craft's barrels (added in 1.14), just as they can be deposited into its chests and trapped chests 

### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Compiled/tested
