### PR TITLE
Reduce separation of static material checks

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -599,10 +599,10 @@ public class AsyncManager extends BukkitRunnable {
                     moveBlocks.add(entry);
             }
 
-            if (type != Material.FIRE && type != Material.AIR && type != Material.CAVE_AIR && type != Material.VOID_AIR) {
+            if (type != Material.FIRE && !type.isAir()) {
                 totalNonNegligibleBlocks++;
             }
-            if (type != Material.FIRE && type != Material.AIR && type != Material.WATER && type != Material.CAVE_AIR && type != Material.VOID_AIR) {
+            if (type != Material.FIRE && !type.isAir() && type != Material.WATER) {
                 totalNonNegligibleWaterBlocks++;
             }
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncTask.java
@@ -23,6 +23,7 @@ import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.FuelBurnEvent;
 import net.countercraft.movecraft.localisation.I18nSupport;
+import net.countercraft.movecraft.util.Tags;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -90,7 +91,7 @@ public abstract class AsyncTask extends BukkitRunnable {
 
         for (MovecraftLocation bTest : craft.getHitBox()) {
             Block b = craft.getWorld().getBlockAt(bTest.getX(), bTest.getY(), bTest.getZ());
-            if (b.getType() == Material.FURNACE) {
+            if (Tags.FURNACES.contains(b.getType())) {
                 InventoryHolder inventoryHolder = (InventoryHolder) b.getState();
                 for (ItemStack stack : inventoryHolder.getInventory()) {
                     if (stack == null || !fuelTypes.containsKey(stack.getType()))
@@ -125,8 +126,8 @@ public abstract class AsyncTask extends BukkitRunnable {
             if (burningFuel < fuelBurnRate) {
                 minAmount = (int) fuelBurnRate;
             }
-            if (iStack.getType() == Material.LAVA_BUCKET || iStack.getType() == Material.WATER_BUCKET || iStack.getType() == Material.MILK_BUCKET) {
-                //If water, lava or milk buckets are accepted as fuel, replace with an empty bucket
+            if (Tags.BUCKETS.contains(iStack.getType())) {
+                //If buckets are accepted as fuel, replace with an empty bucket
                 iStack.setType(Material.BUCKET);
             } else if (amount == minAmount) {
                 inventoryHolder.getInventory().remove(iStack);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -31,6 +31,7 @@ import net.countercraft.movecraft.mapUpdater.update.CraftRotateCommand;
 import net.countercraft.movecraft.mapUpdater.update.EntityUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
 import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.util.Tags;
 import net.countercraft.movecraft.util.hitboxes.MutableHitBox;
 import net.countercraft.movecraft.util.hitboxes.SetHitBox;
 import net.kyori.adventure.text.Component;
@@ -112,8 +113,7 @@ public class RotationTask extends AsyncTask {
 
             Material oldMaterial = originalLocation.toBukkit(w).getBlock().getType();
             //prevent chests collision
-            if ((oldMaterial.equals(Material.CHEST) || oldMaterial.equals(Material.TRAPPED_CHEST)) &&
-                    !checkChests(oldMaterial, newLocation)) {
+            if (Tags.CHESTS.contains(oldMaterial) && !checkChests(oldMaterial, newLocation)) {
                 failed = true;
                 failMessage = String.format(I18nSupport.getInternationalisedString("Rotation - Craft is obstructed") + " @ %d,%d,%d", newLocation.getX(), newLocation.getY(), newLocation.getZ());
                 break;
@@ -126,10 +126,8 @@ public class RotationTask extends AsyncTask {
             }
 
             Material newMaterial = newLocation.toBukkit(w).getBlock().getType();
-            if ((newMaterial == Material.AIR) || (newMaterial == Material.PISTON_HEAD) || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(newMaterial)) {
-                //getCraft().getPhaseBlocks().put(newLocation.toBukkit(w), newMaterial);
+            if (newMaterial.isAir() || (newMaterial == Material.PISTON_HEAD) || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(newMaterial))
                 continue;
-            }
 
             if (!oldHitBox.contains(newLocation)) {
                 failed = true;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -22,6 +22,7 @@ import net.countercraft.movecraft.mapUpdater.update.EntityUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.ExplosionUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.ItemDropUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
+import net.countercraft.movecraft.util.Tags;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.countercraft.movecraft.util.hitboxes.MutableHitBox;
 import net.countercraft.movecraft.util.hitboxes.SolidHitBox;
@@ -59,28 +60,6 @@ import java.util.logging.Logger;
 import static net.countercraft.movecraft.util.MathUtils.withinWorldBorder;
 
 public class TranslationTask extends AsyncTask {
-    private static final EnumSet<Material> FALL_THROUGH_BLOCKS = EnumSet.noneOf(Material.class);
-    static {
-        FALL_THROUGH_BLOCKS.add(Material.AIR);
-        FALL_THROUGH_BLOCKS.add(Material.WATER);
-        FALL_THROUGH_BLOCKS.add(Material.LAVA);
-        FALL_THROUGH_BLOCKS.add(Material.DEAD_BUSH);
-        FALL_THROUGH_BLOCKS.addAll(Tag.CORAL_PLANTS.getValues());
-        FALL_THROUGH_BLOCKS.add(Material.BROWN_MUSHROOM);
-        FALL_THROUGH_BLOCKS.add(Material.RED_MUSHROOM);
-        FALL_THROUGH_BLOCKS.add(Material.TORCH);
-        FALL_THROUGH_BLOCKS.add(Material.FIRE);
-        FALL_THROUGH_BLOCKS.add(Material.REDSTONE_WIRE);
-        FALL_THROUGH_BLOCKS.add(Material.LADDER);
-        FALL_THROUGH_BLOCKS.addAll(Tag.SIGNS.getValues());
-        FALL_THROUGH_BLOCKS.add(Material.LEVER);
-        FALL_THROUGH_BLOCKS.add(Material.STONE_BUTTON);
-        FALL_THROUGH_BLOCKS.add(Material.SNOW);
-        FALL_THROUGH_BLOCKS.add(Material.CARROT);
-        FALL_THROUGH_BLOCKS.add(Material.POTATO);
-        FALL_THROUGH_BLOCKS.addAll(Tag.FENCES.getValues());
-    }
-
     private World world;
     private int dx, dy, dz;
     private SetHitBox newHitBox;
@@ -191,7 +170,7 @@ public class TranslationTask extends AsyncTask {
             int testY = minY;
             while (testY > 0){
                 testY--;
-                if (craft.getWorld().getBlockAt(middle.getX(),testY,middle.getZ()).getType() != Material.AIR)
+                if (!craft.getWorld().getBlockAt(middle.getX(),testY,middle.getZ()).getType().isAir())
                     break;
             }
             if (maxY - testY > (int) craft.getType().getPerWorldProperty(CraftType.PER_WORLD_MAX_HEIGHT_ABOVE_GROUND, world)) {
@@ -213,7 +192,7 @@ public class TranslationTask extends AsyncTask {
                 int centreMinY = oldHitBox.getMinYAt(midPoint.getX(), midPoint.getZ());
                 int groundY = centreMinY;
                 World w = craft.getWorld();
-                while (w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType() == Material.AIR || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType())){
+                while (w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType().isAir() || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType())){
                     groundY--;
                 }
                 if (centreMinY - groundY > craft.getType().getIntProperty(CraftType.HOVER_LIMIT)){
@@ -262,7 +241,7 @@ public class TranslationTask extends AsyncTask {
             }
             final Material testMaterial = newLocation.toBukkit(world).getBlock().getType();
 
-            if ((testMaterial.equals(Material.CHEST) || testMaterial.equals(Material.TRAPPED_CHEST)) && checkChests(testMaterial, newLocation)) {
+            if (Tags.CHESTS.contains(testMaterial) && checkChests(testMaterial, newLocation)) {
                 //prevent chests collision
                 fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft is obstructed") + " @ %d,%d,%d,%s", newLocation.getX(), newLocation.getY(), newLocation.getZ(), newLocation.toBukkit(craft.getWorld()).getBlock().getType().toString()));
                 return;
@@ -274,16 +253,13 @@ public class TranslationTask extends AsyncTask {
 
             boolean blockObstructed;
             if (craft.getSinking()) {
-                blockObstructed = !FALL_THROUGH_BLOCKS.contains(testMaterial);
+                blockObstructed = !Tags.FALL_THROUGH_BLOCKS.contains(testMaterial);
             } else {
                 blockObstructed = !craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(testMaterial) && !testMaterial.equals(Material.AIR);
             }
 
-            boolean ignoreBlock = false;
+            boolean ignoreBlock = oldLocation.toBukkit(craft.getWorld()).getBlock().getType().isAir() && blockObstructed;
             // air never obstructs anything (changed 4/18/2017 to prevent drilling machines)
-            if (oldLocation.toBukkit(craft.getWorld()).getBlock().getType().equals(Material.AIR) && blockObstructed) {
-                ignoreBlock = true;
-            }
 
             if (blockObstructed && !harvestBlocks.isEmpty() && harvestBlocks.contains(testMaterial)) {
                 Material tmpType = oldLocation.toBukkit(craft.getWorld()).getBlock().getType();
@@ -317,7 +293,7 @@ public class TranslationTask extends AsyncTask {
         if (craft.getType().getMaterialSetProperty(CraftType.FORBIDDEN_HOVER_OVER_BLOCKS).size() > 0){
             MovecraftLocation test = new MovecraftLocation(newHitBox.getMidPoint().getX(), newHitBox.getMinY(), newHitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
-            while (test.toBukkit(world).getBlock().getType() == Material.AIR){
+            while (test.toBukkit(world).getBlock().getType().isAir()){
                 test = test.translate(0, -1, 0);
             }
             Material testType = test.toBukkit(world).getBlock().getType();
@@ -337,7 +313,7 @@ public class TranslationTask extends AsyncTask {
         if(craft.getSinking()){
             List<MovecraftLocation> air = new ArrayList<>();
             for(MovecraftLocation location: oldHitBox){
-                if(location.toBukkit(craft.getWorld()).getBlock().getType() == Material.AIR){
+                if(location.toBukkit(craft.getWorld()).getBlock().getType().isAir()){
                     air.add(location.translate(dx,dy,dz));
                 }
             }
@@ -348,7 +324,7 @@ public class TranslationTask extends AsyncTask {
                         continue;
                     }
                     Location loc = location.toBukkit(craft.getWorld());
-                    if (!loc.getBlock().getType().equals(Material.AIR)  && ThreadLocalRandom.current().nextDouble(1) < .05) {
+                    if (!loc.getBlock().getType().isAir() && ThreadLocalRandom.current().nextDouble(1) < .05) {
                         updates.add(new ExplosionUpdateCommand( loc, craft.getType().getFloatProperty(CraftType.EXPLODE_ON_CRASH)));
                         collisionExplosion = true;
                     }
@@ -374,7 +350,7 @@ public class TranslationTask extends AsyncTask {
                 }*/
                 Location oldLocation = location.translate(-dx,-dy,-dz).toBukkit(craft.getWorld());
                 Location newLocation = location.toBukkit(world);
-                if (!oldLocation.getBlock().getType().equals(Material.AIR)) {
+                if (!oldLocation.getBlock().getType().isAir()) {
                     CraftCollisionExplosionEvent e = new CraftCollisionExplosionEvent(craft, newLocation, craft.getWorld());
                     Bukkit.getServer().getPluginManager().callEvent(e);
                     if(!e.isCancelled()) {
@@ -475,7 +451,7 @@ public class TranslationTask extends AsyncTask {
         //find chests
         for (MovecraftLocation loc : oldHitBox) {
             Block block = craft.getWorld().getBlockAt(loc.getX(), loc.getY(), loc.getZ());
-            if (block.getType() == Material.CHEST || block.getType() == Material.TRAPPED_CHEST)
+            if (Tags.CHESTS.contains(block.getType()))
                 chests.add(((InventoryHolder) (block.getState())).getInventory());
         }
 
@@ -626,7 +602,7 @@ public class TranslationTask extends AsyncTask {
         for (Inventory inv : inventories) {
             int capacity = 0;
             for (ItemStack itemStack : inv) {
-                if (itemStack == null || itemStack.getType() == Material.AIR) {
+                if (itemStack == null || itemStack.getType().isAir()) {
                     capacity += stack.getMaxStackSize();
                 } else if (itemStack.isSimilar(stack)) {
                     capacity += stack.getMaxStackSize() - itemStack.getAmount();
@@ -674,7 +650,7 @@ public class TranslationTask extends AsyncTask {
         int elevation = 0;
         for (MovecraftLocation ml : collisionBox){
             Material testType = ml.toBukkit(craft.getWorld()).getBlock().getType();
-            if (testType == Material.AIR ||
+            if (testType.isAir() ||
                     craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(testType) ||
                     (craft.getType().getMaterialSetProperty(CraftType.HARVEST_BLOCKS).contains(testType) &&
                             craft.getType().getMaterialSetProperty(CraftType.HARVESTER_BLADE_BLOCKS).contains(ml.translate(-dx, -dy, -dz).toBukkit(craft.getWorld()).getBlock().getType()))) {
@@ -767,13 +743,12 @@ public class TranslationTask extends AsyncTask {
             translatedBottomLocs.add(bottomLoc.translate(dx, dy, dz));
             Material testType = bottomLoc.translate(0, -1, 0).toBukkit(craft.getWorld()).getBlock().getType();
             //If the lowest part of the bottom locs touch the ground, return true anyways
-            if (testType == Material.AIR){
+            if (testType.isAir())
                 continue;
-            } else if (craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(testType)) {
+            else if (craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(testType))
                 continue;
-            } else if (craft.getType().getMaterialSetProperty(CraftType.HARVEST_BLOCKS).contains(testType) && craft.getType().getMaterialSetProperty(CraftType.HARVESTER_BLADE_BLOCKS).contains(bottomLoc.toBukkit(craft.getWorld()).getBlock().getType())) {
+            else if (craft.getType().getMaterialSetProperty(CraftType.HARVEST_BLOCKS).contains(testType) && craft.getType().getMaterialSetProperty(CraftType.HARVESTER_BLADE_BLOCKS).contains(bottomLoc.toBukkit(craft.getWorld()).getBlock().getType()))
                 continue;
-            }
 
             bottomLocsOnGround = true;
         }
@@ -784,7 +759,7 @@ public class TranslationTask extends AsyncTask {
             final CraftType type = craft.getType();
             if (hitBox.contains(beneath) ||
                     bottomLocs.contains(beneath) ||
-                    testType == Material.AIR ||
+                    testType.isAir() ||
                     type.getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(testType) ||
                     (type.getMaterialSetProperty(CraftType.HARVEST_BLOCKS).contains(testType) && type.getMaterialSetProperty(CraftType.HARVESTER_BLADE_BLOCKS).contains(translatedBottomLoc.translate(-dx, -dy, -dz).toBukkit(craft.getWorld()).getBlock().getType()))){
                 continue;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -15,6 +15,7 @@ import net.countercraft.movecraft.processing.MovecraftWorld;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.processing.tasks.detection.DetectionTask;
 import net.countercraft.movecraft.util.Counter;
+import net.countercraft.movecraft.util.Tags;
 import net.countercraft.movecraft.util.TimingData;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.countercraft.movecraft.util.hitboxes.MutableHitBox;
@@ -393,7 +394,11 @@ public abstract class BaseCraft implements Craft{
             }
         }
 
-        int chestPenalty = (int)((materials.get(Material.CHEST) + materials.get(Material.TRAPPED_CHEST)) * type.getDoubleProperty(CraftType.CHEST_PENALTY));
+        int chestPenalty = 0;
+        for(Material m : Tags.CHESTS) {
+            chestPenalty += materials.get(m);
+        }
+        chestPenalty *= type.getDoubleProperty(CraftType.CHEST_PENALTY);
         if(!cruising)
             return ((int) type.getPerWorldProperty(CraftType.PER_WORLD_TICK_COOLDOWN, w) + chestPenalty) * (type.getBoolProperty(CraftType.GEAR_SHIFTS_AFFECT_TICK_COOLDOWN) ? currentGear : 1);
 
@@ -481,7 +486,7 @@ public abstract class BaseCraft implements Craft{
                 Material material = w.getBlockAt(posX, posY, posZ).getType();
                 if (material == Material.WATER)
                     numWater++;
-                if (material == Material.AIR)
+                if (material.isAir())
                     numAir++;
             }
             posZ = hitBox.getMaxZ() + 1;
@@ -489,7 +494,7 @@ public abstract class BaseCraft implements Craft{
                 Material material = w.getBlockAt(posX, posY, posZ).getType();
                 if (material == Material.WATER)
                     numWater++;
-                if (material == Material.AIR)
+                if (material.isAir())
                     numAir++;
             }
             posX = hitBox.getMinX() - 1;
@@ -497,7 +502,7 @@ public abstract class BaseCraft implements Craft{
                 Material material = w.getBlockAt(posX, posY, posZ).getType();
                 if (material == Material.WATER)
                     numWater++;
-                if (material == Material.AIR)
+                if (material.isAir())
                     numAir++;
             }
             posX = hitBox.getMaxX() + 1;
@@ -505,7 +510,7 @@ public abstract class BaseCraft implements Craft{
                 Material material = w.getBlockAt(posX, posY, posZ).getType();
                 if (material == Material.WATER)
                     numWater++;
-                if (material == Material.AIR)
+                if (material.isAir())
                     numAir++;
             }
             if (numWater > numAir) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -23,6 +23,7 @@ import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.util.Tags;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -168,29 +169,19 @@ public class BlockListener implements Listener {
 
         Block block = event.getBlock();
 
-//        final int[] fragileBlocks = new int[]{26, 34, 50, 55, 63, 64, 65, 68, 69, 70, 71, 72, 75, 76, 77, 93, 94, 96, 131, 132, 143, 147, 148, 149, 150, 151, 171, 193, 194, 195, 196, 197};
-        final EnumSet<Material> fragileMaterials = EnumSet.of(Material.PISTON_HEAD, Material.TORCH, Material.REDSTONE_WIRE, Material.LADDER);
-        fragileMaterials.addAll(Tag.DOORS.getValues());
-        fragileMaterials.addAll(Tag.CARPETS.getValues());
-        fragileMaterials.addAll(Tag.RAILS.getValues());
-        fragileMaterials.addAll(Tag.WOODEN_PRESSURE_PLATES.getValues());
         CraftManager.getInstance().getCraftsInWorld(block.getWorld());
         for (Craft tcraft : CraftManager.getInstance().getCraftsInWorld(block.getWorld())) {
             MovecraftLocation mloc = new MovecraftLocation(block.getX(), block.getY(), block.getZ());
             if (!MathUtils.locIsNearCraftFast(tcraft, mloc)) {
                 continue;
             }
-            if (fragileMaterials.contains(event.getBlock().getType())) {
+            if(Tags.FRAGILE_MATERIALS.contains(event.getBlock().getType())) {
                 BlockData m = block.getBlockData();
                 BlockFace face = BlockFace.DOWN;
-                boolean faceAlwaysDown = false;
-                if (block.getType() == Material.COMPARATOR || block.getType() == Material.REPEATER)
-                    faceAlwaysDown = true;
-                if (m instanceof Attachable && !faceAlwaysDown) {
+                boolean faceAlwaysDown = block.getType() == Material.COMPARATOR || block.getType() == Material.REPEATER;
+                if (m instanceof Attachable && !faceAlwaysDown)
                     face = ((Attachable) m).getAttachedFace();
-                }
                 if (!event.getBlock().getRelative(face).getType().isSolid()) {
-//						if(event.getEventName().equals("BlockPhysicsEvent")) {
                     event.setCancelled(true);
                     return;
                 }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -15,6 +15,7 @@ import net.countercraft.movecraft.events.CraftReleaseEvent;
 import net.countercraft.movecraft.events.SignTranslateEvent;
 import net.countercraft.movecraft.util.CollectionUtils;
 import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.util.Tags;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.countercraft.movecraft.util.hitboxes.SolidHitBox;
 import net.countercraft.movecraft.util.hitboxes.SetHitBox;
@@ -69,10 +70,9 @@ public class CraftRotateCommand extends UpdateCommand {
         long time = System.nanoTime();
         final Set<Material> passthroughBlocks = new HashSet<>(craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS));
         if(craft.getSinking()){
-            passthroughBlocks.add(Material.WATER);
+            passthroughBlocks.addAll(Tags.FLUID);
             passthroughBlocks.addAll(Tag.LEAVES.getValues());
-            passthroughBlocks.add(Material.TALL_GRASS);
-            passthroughBlocks.add(Material.GRASS);
+            passthroughBlocks.addAll(Tags.SINKING_PASSTHROUGH);
         }
         if (!passthroughBlocks.isEmpty()) {
             SetHitBox originalLocations = new SetHitBox();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -15,6 +15,7 @@ import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
 import net.countercraft.movecraft.events.SignTranslateEvent;
 import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.util.Tags;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.countercraft.movecraft.util.hitboxes.SetHitBox;
 import net.countercraft.movecraft.util.hitboxes.SolidHitBox;
@@ -77,10 +78,9 @@ public class CraftTranslateCommand extends UpdateCommand {
         World oldWorld = craft.getWorld();
         final Set<Material> passthroughBlocks = new HashSet<>(craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS));
         if(craft.getSinking()){
-            passthroughBlocks.add(Material.WATER);
+            passthroughBlocks.addAll(Tags.FLUID);
             passthroughBlocks.addAll(Tag.LEAVES.getValues());
-            passthroughBlocks.add(Material.TALL_GRASS);
-            passthroughBlocks.add(Material.GRASS);
+            passthroughBlocks.addAll(Tags.SINKING_PASSTHROUGH);
         }
         if(passthroughBlocks.isEmpty()){
             //translate the craft

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/translation/TranslationTask.java
@@ -93,14 +93,12 @@ public class TranslationTask implements Supplier<Effect> {
         for(var originLocation : craft.getHitBox()){
             var originMaterial = craft.getMovecraftWorld().getMaterial(originLocation);
             // Remove air from hitboxes
-            if(Tags.AIR.contains(originMaterial)){
+            if(originMaterial.isAir())
                 continue;
-            }
-            if(originMaterial == Material.FURNACE){
+            if(Tags.FURNACES.contains(originMaterial)) {
                 var state = craft.getMovecraftWorld().getState(originLocation);
-                if(state instanceof FurnaceInventory) {
+                if(state instanceof FurnaceInventory)
                     fuelSources.add((FurnaceInventory) state);
-                }
             }
 
             var destination = originLocation.add(translation);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/translation/validators/HoverValidator.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/translation/validators/HoverValidator.java
@@ -18,7 +18,7 @@ public class HoverValidator implements TetradicPredicate<MovecraftLocation, Move
         if (type.getMaterialSetProperty(CraftType.FORBIDDEN_HOVER_OVER_BLOCKS).size() > 0){
             MovecraftLocation test = new MovecraftLocation(hitBox.getMidPoint().getX(), hitBox.getMinY(), hitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
-            while (world.getMaterial(test) == Material.AIR){
+            while (world.getMaterial(test).isAir()) {
                 test = test.translate(0, -1, 0);
             }
             Material testType = world.getMaterial(test);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
@@ -6,6 +6,7 @@ import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftDetectEvent;
 import net.countercraft.movecraft.events.SignTranslateEvent;
 import net.countercraft.movecraft.util.Counter;
+import net.countercraft.movecraft.util.Tags;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -66,19 +67,18 @@ public final class StatusSign implements Listener{
         }
 
         for (MovecraftLocation ml : craft.getHitBox()) {
-            Material blockID = craft.getWorld().getBlockAt(ml.getX(), ml.getY(), ml.getZ()).getType();
-            foundBlocks.add(blockID);
+            Material material = craft.getWorld().getBlockAt(ml.getX(), ml.getY(), ml.getZ()).getType();
+            foundBlocks.add(material);
 
-            if (blockID == Material.FURNACE) {
+            if(Tags.FURNACES.contains(material)) {
                 InventoryHolder inventoryHolder = (InventoryHolder) craft.getWorld().getBlockAt(ml.getX(), ml.getY(), ml.getZ()).getState();
                 for (ItemStack iStack : inventoryHolder.getInventory()) {
-                    if (iStack == null || !fuelTypes.containsKey(iStack.getType())) {
+                    if (iStack == null || !fuelTypes.containsKey(iStack.getType()))
                         continue;
-                    }
                     fuel += iStack.getAmount() * (double) fuelTypes.get(iStack.getType());
                 }
             }
-            if (blockID != Material.AIR && blockID != Material.FIRE) {
+            if(!material.isAir() && material != Material.FIRE) {
                 totalBlocks++;
             }
         }

--- a/modules/api/src/main/java/net/countercraft/movecraft/util/Tags.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/util/Tags.java
@@ -10,14 +10,51 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Tags {
 
-    public static final EnumSet<Material> AIR = EnumSet.of(Material.AIR, Material.CAVE_AIR, Material.VOID_AIR);
     public static final EnumSet<Material> FLUID = EnumSet.of(Material.WATER, Material.LAVA);
+    public static final EnumSet<Material> CHESTS = EnumSet.of(Material.CHEST, Material.TRAPPED_CHEST, Material.BARREL);
+    public static final EnumSet<Material> FURNACES = EnumSet.of(Material.FURNACE, Material.BLAST_FURNACE, Material.SMOKER);
+    public static final EnumSet<Material> SINKING_PASSTHROUGH = EnumSet.of(Material.TALL_GRASS, Material.GRASS);
+    public static final EnumSet<Material> FRAGILE_MATERIALS = EnumSet.noneOf(Material.class);
+    public static final EnumSet<Material> FALL_THROUGH_BLOCKS = EnumSet.noneOf(Material.class);
+    public static final EnumSet<Material> BUCKETS = EnumSet.of(Material.LAVA_BUCKET, Material.WATER_BUCKET, Material.MILK_BUCKET, Material.COD_BUCKET, Material.PUFFERFISH_BUCKET, Material.SALMON_BUCKET, Material.TROPICAL_FISH_BUCKET);
+
+    static {
+        FRAGILE_MATERIALS.add(Material.PISTON_HEAD);
+        FRAGILE_MATERIALS.add(Material.TORCH);
+        FRAGILE_MATERIALS.add(Material.REDSTONE_WIRE);
+        FRAGILE_MATERIALS.add(Material.LADDER);
+        FRAGILE_MATERIALS.addAll(Tag.DOORS.getValues());
+        FRAGILE_MATERIALS.addAll(Tag.CARPETS.getValues());
+        FRAGILE_MATERIALS.addAll(Tag.RAILS.getValues());
+        FRAGILE_MATERIALS.addAll(Tag.WOODEN_PRESSURE_PLATES.getValues());
+
+        FALL_THROUGH_BLOCKS.add(Material.AIR);
+        FALL_THROUGH_BLOCKS.add(Material.WATER);
+        FALL_THROUGH_BLOCKS.add(Material.LAVA);
+        FALL_THROUGH_BLOCKS.add(Material.DEAD_BUSH);
+        FALL_THROUGH_BLOCKS.addAll(Tag.CORAL_PLANTS.getValues());
+        FALL_THROUGH_BLOCKS.add(Material.BROWN_MUSHROOM);
+        FALL_THROUGH_BLOCKS.add(Material.RED_MUSHROOM);
+        FALL_THROUGH_BLOCKS.add(Material.TORCH);
+        FALL_THROUGH_BLOCKS.add(Material.FIRE);
+        FALL_THROUGH_BLOCKS.add(Material.REDSTONE_WIRE);
+        FALL_THROUGH_BLOCKS.add(Material.LADDER);
+        FALL_THROUGH_BLOCKS.addAll(Tag.SIGNS.getValues());
+        FALL_THROUGH_BLOCKS.add(Material.LEVER);
+        FALL_THROUGH_BLOCKS.add(Material.STONE_BUTTON);
+        FALL_THROUGH_BLOCKS.add(Material.SNOW);
+        FALL_THROUGH_BLOCKS.add(Material.CARROT);
+        FALL_THROUGH_BLOCKS.add(Material.POTATO);
+        FALL_THROUGH_BLOCKS.addAll(Tag.FENCES.getValues());
+    }
 
     @Nullable
-    public static EnumSet<Material> parseBlockRegistry(@NotNull String string){
+    public static EnumSet<Material> parseBlockRegistry(@NotNull String string) {
         if(!string.startsWith("#")){
             return null;
         }
@@ -31,7 +68,7 @@ public class Tags {
     }
 
     @Nullable
-    public static <T extends Enum<T> & Keyed> EnumSet<T> parseRegistry(@NotNull String identifier, String registry, Class<T> clazz){
+    public static <T extends Enum<T> & Keyed> EnumSet<T> parseRegistry(@NotNull String identifier, String registry, Class<T> clazz) {
         if(!identifier.startsWith("#")){
             return null;
         }
@@ -56,7 +93,7 @@ public class Tags {
      */
     @SuppressWarnings("deprecation")
     @Nullable
-    public static NamespacedKey keyFromString(@NotNull String string){
+    public static NamespacedKey keyFromString(@NotNull String string) {
         try{
             if(string.contains(":")){
                 int index = string.indexOf(':');


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
The goal of this PR is to move as many references to static materials into the singular Tags class, or replace them with vanilla Tag class references where possible.  This PR will fix problems with barrels not being registered as a chest type block along with cave and void air problems.

This PR supersedes #457.

### Checklist
- [x] Proper internationalization
- [x] Compiled
- [x] Tested
