### PR TITLE
Fix setBlockFast on 1.18 

### DIFF
--- a/modules/v1_18_R1/src/main/java/net/countercraft/movecraft/compat/v1_18_R1/IWorldHandler.java
+++ b/modules/v1_18_R1/src/main/java/net/countercraft/movecraft/compat/v1_18_R1/IWorldHandler.java
@@ -202,14 +202,12 @@ public class IWorldHandler extends WorldHandler {
     }
 
     private void setBlockFast(@NotNull Level world, @NotNull BlockPos position,@NotNull BlockState data) {
-        world.setBlockAndUpdate(position, data);
-        /*
         LevelChunk chunk = world.getChunkAt(position);
-        LevelChunkSection LevelChunkSection = chunk.getSections()[position.getY()>>4];
+        LevelChunkSection LevelChunkSection = chunk.getSections()[(position.getY() >> 4) - chunk.getMinSection()];
         if (LevelChunkSection == null) {
             // Put a GLASS block to initialize the section. It will be replaced next with the real block.
             chunk.setBlockState(position, Blocks.GLASS.defaultBlockState(), false);
-            LevelChunkSection = chunk.getSections()[position.getY() >> 4];
+            LevelChunkSection = chunk.getSections()[(position.getY() >> 4) - chunk.getMinSection()];
         }
         if(LevelChunkSection.getBlockState(position.getX()&15, position.getY()&15, position.getZ()&15).equals(data)){
             //Block is already of correct type and data, don't overwrite
@@ -219,7 +217,6 @@ public class IWorldHandler extends WorldHandler {
         world.sendBlockUpdated(position, data, data, 3);
         world.getLightEngine().checkBlock(position); // boolean corresponds to if chunk section empty
         chunk.setUnsaved(true);
-        */
     }
 
     @Override


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
1.18 allows terrain to generate below y = 0, and chunk sections can be negative as a result. The minimum chunk section at y -64 has a value of -4. This needs to be accounted for in the world handler. By subtracting the minimum chunk section, we ensure that the section index is both correct and always greater than or equal to zero

To test this, I piloted a craft at y -64, y 64 and y 300. The craft moved and rotated as expected.

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
I suspect this will fix #452 if applied to the 1.17 world handler, but I have not had the time to test this

### Checklist
- [ ] Proper internationalization
- [x] Tested

