### PR TITLE
Allow submersible ships to pass through ocean plants

### DIFF
--- a/modules/Movecraft/src/main/resources/types/BigSubAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/BigSubAirship.craft
@@ -142,3 +142,9 @@ flyblocks:
     water: # so is water
         - 0.0
         - 1.0
+passthroughBlocks:
+    - kelp_plant
+    - seagrass
+    - kelp
+    - tall_seagrass
+    - bubble_column

--- a/modules/Movecraft/src/main/resources/types/SubAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/SubAirship.craft
@@ -141,3 +141,9 @@ flyblocks:
     water: # so is water
         - 0.0
         - 1.0
+passthroughBlocks:
+    - kelp_plant
+    - seagrass
+    - kelp
+    - tall_seagrass
+    - bubble_column


### PR DESCRIPTION
It doesn't make a whole lot of sense to me to have default craft types for submersible ships that can't do this, because with modern Minecraft oceans having lots of kelp and things, it makes them relatively useless. Although if there are counter-arguments I'm willing to hear and discuss them.