### PR TITLE
Fixes to RequiredBlockEntry

### DIFF
--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/type/RequiredBlockEntry.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/type/RequiredBlockEntry.java
@@ -47,7 +47,7 @@ public class RequiredBlockEntry {
     }
 
     public boolean check(int count, int size, double sinkPercent) {
-        double blockPercent = 100D * count / size;
+        double blockPercent = 100D * (double) count / size;
         if(numericMin) {
             if(count < min)
                 return false;
@@ -71,7 +71,7 @@ public class RequiredBlockEntry {
     }
 
     public Pair<DetectionResult, String> detect(int count, int size) {
-        double blockPercent = 100D * count / size;
+        double blockPercent = 100D * (double) count / size;
 
         if(numericMin && count < min)
             return new Pair<>(DetectionResult.NOT_ENOUGH, String.format("%d < %d", count, (int) min));

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/type/RequiredBlockEntry.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/type/RequiredBlockEntry.java
@@ -53,7 +53,7 @@ public class RequiredBlockEntry {
                 return false;
         }
         else {
-            if(blockPercent * sinkPercent < min)
+            if(blockPercent < min * sinkPercent)
                 return false;
         }
         if(numericMax) {


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes

This PR fixes two issues related to the `RequiredBlockEntry` class.

Firstly, it fixes integer division being used when calculating `blockPercent`. This led to imprecision that could prevent crafts which just about satisfied the flyblock requirements from being piloted.

Secondly, it fixes the `sinkPercent` craft flag. Currently, a craft will sink if `blockPercent * sinkPercent < min`. 
Suppose:
* `blockPercent` (the percentage of the craft made from the flyblock) is `6.0` 
* `sinkPercent` is set to `80.0` in a craft file (so is `0.8` in the code), 
* `min` for this flyblock is `5.0`. 

Then `blockPercent * sinkPercent` will be `4.8`, and the craft will always sink immediately after being piloted. The PR fixes the condition so that the craft will only sink if `blockPercent < min * sinkPercent`, which IIRC is what it previously was.

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
N/A

### Checklist
- [x] Tested

