### PR TITLE
Expose max, min, numericMax and numericMin in RequiredBlockEntry

### DIFF
--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/type/RequiredBlockEntry.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/type/RequiredBlockEntry.java
@@ -85,4 +85,20 @@ public class RequiredBlockEntry {
 
         return new Pair<>(DetectionResult.SUCCESS, "");
     }
+
+    public double getMax() {
+        return max;
+    }
+
+    public boolean isNumericMax() {
+        return numericMax;
+    }
+
+    public double getMin() {
+        return min;
+    }
+
+    public boolean isNumericMin() {
+        return numericMin;
+    }
 }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes

This PR adds getters for `max`, `min`, `numericMax` and `numericMin` in the `RequiredBlockEntry` class.

Example use case: creating a command that returns the number of blocks required to make a craft of a given size. 

![Screenshot](https://i.gyazo.com/1023bf2911c53aa576d1f077a06e8f26.png)


### Checklist
- [x] Tested
