### PR TITLE
Fix hovering when over the void

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -193,8 +193,9 @@ public class TranslationTask extends AsyncTask {
                 int centreMinY = oldHitBox.getMinYAt(midPoint.getX(), midPoint.getZ());
                 int groundY = centreMinY;
                 World w = craft.getWorld();
-                int minimumHeight = WorldUtils.getWorldMinHeightLimit(w);
-                while (groundY - 1 >= minimumHeight && w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType().isAir() || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType())){
+                while (groundY - 1 >= WorldUtils.getWorldMinHeightLimit(w)
+                        && (w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType().isAir()
+                        || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType()))) {
                     groundY--;
                 }
                 if (centreMinY - groundY > craft.getType().getIntProperty(CraftType.HOVER_LIMIT)){

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -23,6 +23,7 @@ import net.countercraft.movecraft.mapUpdater.update.ExplosionUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.ItemDropUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
 import net.countercraft.movecraft.util.Tags;
+import net.countercraft.movecraft.util.WorldUtils;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.countercraft.movecraft.util.hitboxes.MutableHitBox;
 import net.countercraft.movecraft.util.hitboxes.SolidHitBox;
@@ -192,7 +193,8 @@ public class TranslationTask extends AsyncTask {
                 int centreMinY = oldHitBox.getMinYAt(midPoint.getX(), midPoint.getZ());
                 int groundY = centreMinY;
                 World w = craft.getWorld();
-                while (w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType().isAir() || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType())){
+                int minimumHeight = WorldUtils.getWorldMinHeightLimit(w);
+                while (groundY - 1 >= minimumHeight && w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType().isAir() || craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS).contains(w.getBlockAt(midPoint.getX(), groundY - 1, midPoint.getZ()).getType())){
                     groundY--;
                 }
                 if (centreMinY - groundY > craft.getType().getIntProperty(CraftType.HOVER_LIMIT)){


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes

If a craft has hover enabled but its midpoint is over the void, the ground Y check loops forever as void air is included in `Material#isAir`. This PR terminates the loop when the minimum height limit of the world is reached. 


<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
Fixes #497

### Checklist
- [x] Tested
