### PR TITLE
1.19.2 and Magic Numbers

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -153,47 +153,47 @@ jobs:
         if: steps.caves.outputs.sucess != 'true' || steps.cavesMojang.outputs.sucess != 'true' || steps.cavesObf.outputs.sucess != 'true'
         run: cd BuildTools && java -jar BuildTools.jar --rev 1.18.2 --remapped
 
-  # Build 1.19.1 NMS
+  # Build 1.19.2 NMS
   wild_1_19_1:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17 # 1.19.1 can only be built with Java 17
+      - name: Set up JDK 17 # 1.19.2 can only be built with Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Cache 1.19.1 Maven package
+      - name: Cache 1.19.2 Maven package
         id: cacheWild
         uses: actions/cache@v2
         with:
           path: |
-            ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/
+            ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/
             ~/.m2/repository/org/spigotmc/spigot-parent/
             ~/.m2/repository/org/spigotmc/minecraft-server/
-          key: ${{ runner.os }}-spigot-1.19.1-all
-          restore-keys: ${{ runner.os }}-spigot-1.19.1-all
+          key: ${{ runner.os }}-spigot-1.19.2-all
+          restore-keys: ${{ runner.os }}-spigot-1.19.2-all
       - name: Cache Maven packages
         id: cacheMain
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2_1.19.1
-          restore-keys: ${{ runner.os }}-m2_1.19.1
+          key: ${{ runner.os }}-m2_1.19.2
+          restore-keys: ${{ runner.os }}-m2_1.19.2
 
       - name: Setup BuildTools
         run: mkdir BuildTools && wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-      - name: Check 1.19.1 Spigot
+      - name: Check 1.19.2 Spigot
         id: wild
-        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/spigot-1.19.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-      - name: Check 1.19.1 Spigot (Mojang)
+        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/spigot-1.19.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      - name: Check 1.19.2 Spigot (Mojang)
         id: wildMojang
-        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/spigot-1.19.1-R0.1-SNAPSHOT-remapped-mojang.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-      - name: Check 1.19.1 Spigot (Obf)
+        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/spigot-1.19.2-R0.1-SNAPSHOT-remapped-mojang.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      - name: Check 1.19.2 Spigot (Obf)
         id: wildObf
-        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/spigot-1.19.1-R0.1-SNAPSHOT-remapped-obf.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-      - name: Build 1.19.1
+        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/spigot-1.19.2-R0.1-SNAPSHOT-remapped-obf.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      - name: Build 1.19.2
         if: steps.wild.outputs.sucess != 'true' || steps.wildMojang.outputs.sucess != 'true' || steps.wildObf.outputs.sucess != 'true'
-        run: cd BuildTools && java -jar BuildTools.jar --rev 1.19.1 --remapped
+        run: cd BuildTools && java -jar BuildTools.jar --rev 1.19.2 --remapped
 
   # Build Movecraft
   build:
@@ -249,16 +249,16 @@ jobs:
           ~/.m2/repository/org/spigotmc/minecraft-server/
         key: ${{ runner.os }}-spigot-1.18.2-all
         restore-keys: ${{ runner.os }}-spigot-1.18.2-all
-    - name: Cache 1.19.1 Maven package
+    - name: Cache 1.19.2 Maven package
       id: cacheWild
       uses: actions/cache@v2
       with:
         path: |
-          ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/
+          ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/
           ~/.m2/repository/org/spigotmc/spigot-parent/
           ~/.m2/repository/org/spigotmc/minecraft-server/
-        key: ${{ runner.os }}-spigot-1.19.1-all
-        restore-keys: ${{ runner.os }}-spigot-1.19.1-all
+        key: ${{ runner.os }}-spigot-1.19.2-all
+        restore-keys: ${{ runner.os }}-spigot-1.19.2-all
 
     - name: Build with Maven
       run: mvn -T 1C -B package --file pom.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,47 +156,47 @@ jobs:
         if: steps.caves.outputs.sucess != 'true' || steps.cavesMojang.outputs.sucess != 'true' || steps.cavesObf.outputs.sucess != 'true'
         run: cd BuildTools && java -jar BuildTools.jar --rev 1.18.2 --remapped
 
-  # Build 1.19.1 NMS
+  # Build 1.19.2 NMS
   wild_1_19_1:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17 # 1.19.1 can only be built with Java 17
+      - name: Set up JDK 17 # 1.19.2 can only be built with Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Cache 1.19.1 Maven package
+      - name: Cache 1.19.2 Maven package
         id: cacheWild
         uses: actions/cache@v2
         with:
           path: |
-            ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/
+            ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/
             ~/.m2/repository/org/spigotmc/spigot-parent/
             ~/.m2/repository/org/spigotmc/minecraft-server/
-          key: ${{ runner.os }}-spigot-1.19.1-all
-          restore-keys: ${{ runner.os }}-spigot-1.19.1-all
+          key: ${{ runner.os }}-spigot-1.19.2-all
+          restore-keys: ${{ runner.os }}-spigot-1.19.2-all
       - name: Cache Maven packages
         id: cacheMain
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2_1.19.1
-          restore-keys: ${{ runner.os }}-m2_1.19.1
+          key: ${{ runner.os }}-m2_1.19.2
+          restore-keys: ${{ runner.os }}-m2_1.19.2
 
       - name: Setup BuildTools
         run: mkdir BuildTools && wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-      - name: Check 1.19.1 Spigot
+      - name: Check 1.19.2 Spigot
         id: wild
-        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/spigot-1.19.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-      - name: Check 1.19.1 Spigot (Mojang)
+        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/spigot-1.19.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      - name: Check 1.19.2 Spigot (Mojang)
         id: wildMojang
-        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/spigot-1.19.1-R0.1-SNAPSHOT-remapped-mojang.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-      - name: Check 1.19.1 Spigot (Obf)
+        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/spigot-1.19.2-R0.1-SNAPSHOT-remapped-mojang.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      - name: Check 1.19.2 Spigot (Obf)
         id: wildObf
-        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/spigot-1.19.1-R0.1-SNAPSHOT-remapped-obf.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-      - name: Build 1.19.1
+        run: test -f ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/spigot-1.19.2-R0.1-SNAPSHOT-remapped-obf.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      - name: Build 1.19.2
         if: steps.wild.outputs.sucess != 'true' || steps.wildMojang.outputs.sucess != 'true' || steps.wildObf.outputs.sucess != 'true'
-        run: cd BuildTools && java -jar BuildTools.jar --rev 1.19.1 --remapped
+        run: cd BuildTools && java -jar BuildTools.jar --rev 1.19.2 --remapped
 
   # Build Movecraft
   publish:
@@ -255,16 +255,16 @@ jobs:
           ~/.m2/repository/org/spigotmc/minecraft-server/
         key: ${{ runner.os }}-spigot-1.18.2-all
         restore-keys: ${{ runner.os }}-spigot-1.18.2-all
-    - name: Cache 1.19.1 Maven package
+    - name: Cache 1.19.2 Maven package
       id: cacheWild
       uses: actions/cache@v2
       with:
         path: |
-          ~/.m2/repository/org/spigotmc/spigot/1.19.1-R0.1-SNAPSHOT/
+          ~/.m2/repository/org/spigotmc/spigot/1.19.2-R0.1-SNAPSHOT/
           ~/.m2/repository/org/spigotmc/spigot-parent/
           ~/.m2/repository/org/spigotmc/minecraft-server/
-        key: ${{ runner.os }}-spigot-1.19.1-all
-        restore-keys: ${{ runner.os }}-spigot-1.19.1-all
+        key: ${{ runner.os }}-spigot-1.19.2-all
+        restore-keys: ${{ runner.os }}-spigot-1.19.2-all
 
     - name: Build with Maven
       run: mvn -T 1C -B package --file pom.xml

--- a/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
+++ b/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
@@ -58,7 +58,7 @@ public class IWorldHandler extends WorldHandler {
 
     public IWorldHandler() {
         String mappings = ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion();
-        if (!mappings.equals("54e89c47309b53737f894f1bf1b0edbe"))
+        if (!mappings.equals("d4b392244df170796f8779ef0fc1f2e9"))
             throw new IllegalStateException("Movecraft is not compatible with this version of Minecraft 1.16: " + mappings);
 
         MethodHandles.Lookup lookup = MethodHandles.lookup();

--- a/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
+++ b/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
@@ -26,6 +26,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,16 +45,22 @@ import java.util.Set;
 @SuppressWarnings("unused")
 public class IWorldHandler extends WorldHandler {
     private static final EnumBlockRotation ROTATION[];
+
     static {
         ROTATION = new EnumBlockRotation[3];
         ROTATION[MovecraftRotation.NONE.ordinal()] = EnumBlockRotation.NONE;
         ROTATION[MovecraftRotation.CLOCKWISE.ordinal()] = EnumBlockRotation.CLOCKWISE_90;
         ROTATION[MovecraftRotation.ANTICLOCKWISE.ordinal()] = EnumBlockRotation.COUNTERCLOCKWISE_90;
     }
+
     private final NextTickProvider tickProvider = new NextTickProvider();
     private MethodHandle internalTeleportMH;
 
     public IWorldHandler() {
+        String mappings = ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion();
+        if (!mappings.equals("54e89c47309b53737f894f1bf1b0edbe"))
+            throw new IllegalStateException("Movecraft is not compatible with this version of Minecraft 1.16: " + mappings);
+
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         Method teleport = null;
         try {
@@ -61,22 +68,24 @@ public class IWorldHandler extends WorldHandler {
             teleport.setAccessible(true);
             internalTeleportMH = lookup.unreflect(teleport);
 
-        } catch (NoSuchMethodException | IllegalAccessException e) {
+        }
+        catch (NoSuchMethodException | IllegalAccessException e) {
             e.printStackTrace();
         }
     }
 
     @Override
-    public void addPlayerLocation(Player player, double x, double y, double z, float yaw, float pitch){
+    public void addPlayerLocation(Player player, double x, double y, double z, float yaw, float pitch) {
         EntityPlayer ePlayer = ((CraftPlayer) player).getHandle();
-        if(internalTeleportMH == null) {
+        if (internalTeleportMH == null) {
             //something went wrong
             super.addPlayerLocation(player, x, y, z, yaw, pitch);
             return;
         }
         try {
             internalTeleportMH.invoke(ePlayer.playerConnection, x, y, z, yaw, pitch, EnumSet.allOf(PacketPlayOutPosition.EnumPlayerTeleportFlags.class));
-        } catch (Throwable throwable) {
+        }
+        catch (Throwable throwable) {
             throwable.printStackTrace();
         }
     }
@@ -86,10 +95,10 @@ public class IWorldHandler extends WorldHandler {
         //*******************************************
         //*      Step one: Convert to Positions     *
         //*******************************************
-        HashMap<BlockPosition,BlockPosition> rotatedPositions = new HashMap<>();
+        HashMap<BlockPosition, BlockPosition> rotatedPositions = new HashMap<>();
         MovecraftRotation counterRotation = rotation == MovecraftRotation.CLOCKWISE ? MovecraftRotation.ANTICLOCKWISE : MovecraftRotation.CLOCKWISE;
-        for(MovecraftLocation newLocation : craft.getHitBox()){
-            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)),locationToPosition(newLocation));
+        for (MovecraftLocation newLocation : craft.getHitBox()) {
+            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)), locationToPosition(newLocation));
         }
         //*******************************************
         //*         Step two: Get the tiles         *
@@ -97,14 +106,14 @@ public class IWorldHandler extends WorldHandler {
         WorldServer nativeWorld = ((CraftWorld) craft.getWorld()).getHandle();
         List<TileHolder> tiles = new ArrayList<>();
         //get the tiles
-        for(BlockPosition position : rotatedPositions.keySet()){
+        for (BlockPosition position : rotatedPositions.keySet()) {
             //TileEntity tile = nativeWorld.removeTileEntity(position);
-            TileEntity tile = removeTileEntity(nativeWorld,position);
-            if(tile == null)
+            TileEntity tile = removeTileEntity(nativeWorld, position);
+            if (tile == null)
                 continue;
             tile.a(ROTATION[rotation.ordinal()]);
             //get the nextTick to move with the tile
-            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld,position), position));
+            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld, position), position));
         }
 
         //*******************************************
@@ -115,12 +124,12 @@ public class IWorldHandler extends WorldHandler {
         //TODO: go by chunks
         //TODO: Don't move unnecessary blocks
         //get the blocks and rotate them
-        HashMap<BlockPosition,IBlockData> blockData = new HashMap<>();
-        for(BlockPosition position : rotatedPositions.keySet()){
-            blockData.put(position,nativeWorld.getType(position).a(ROTATION[rotation.ordinal()]));
+        HashMap<BlockPosition, IBlockData> blockData = new HashMap<>();
+        for (BlockPosition position : rotatedPositions.keySet()) {
+            blockData.put(position, nativeWorld.getType(position).a(ROTATION[rotation.ordinal()]));
         }
         //create the new block
-        for(Map.Entry<BlockPosition,IBlockData> entry : blockData.entrySet()) {
+        for (Map.Entry<BlockPosition, IBlockData> entry : blockData.entrySet()) {
             setBlockFast(nativeWorld, rotatedPositions.get(entry.getKey()), entry.getValue());
         }
 
@@ -129,20 +138,20 @@ public class IWorldHandler extends WorldHandler {
         //*    Step four: replace all the tiles     *
         //*******************************************
         //TODO: go by chunks
-        for(TileHolder tileHolder : tiles){
-            moveTileEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()),tileHolder.getTile());
-            if(tileHolder.getNextTick()==null)
+        for (TileHolder tileHolder : tiles) {
+            moveTileEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()), tileHolder.getTile());
+            if (tileHolder.getNextTick() == null)
                 continue;
             final long currentTime = nativeWorld.worldData.getTime();
-            nativeWorld.getBlockTickList().a(rotatedPositions.get(tileHolder.getNextTick().a), (Block)tileHolder.getNextTick().b(), (int) (tileHolder.getNextTick().b - currentTime), tileHolder.getNextTick().c);
+            nativeWorld.getBlockTickList().a(rotatedPositions.get(tileHolder.getNextTick().a), (Block) tileHolder.getNextTick().b(), (int) (tileHolder.getNextTick().b - currentTime), tileHolder.getNextTick().c);
         }
 
         //*******************************************
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         //TODO: add support for pass-through
-        Collection<BlockPosition> deletePositions =  CollectionUtils.filter(rotatedPositions.keySet(),rotatedPositions.values());
-        for(BlockPosition position : deletePositions){
+        Collection<BlockPosition> deletePositions = CollectionUtils.filter(rotatedPositions.keySet(), rotatedPositions.values());
+        for (BlockPosition position : deletePositions) {
             setBlockFast(nativeWorld, position, Blocks.AIR.getBlockData());
         }
     }
@@ -195,7 +204,7 @@ public class IWorldHandler extends WorldHandler {
             newPositions.add(position.a(translateVector));
         }
         //create the new block
-        for(int i = 0, positionSize = newPositions.size(); i<positionSize; i++) {
+        for (int i = 0, positionSize = newPositions.size(); i < positionSize; i++) {
             setBlockFast(nativeWorld, newPositions.get(i), blockData.get(i));
         }
         //*******************************************
@@ -214,7 +223,8 @@ public class IWorldHandler extends WorldHandler {
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         List<BlockPosition> deletePositions = positions;
-        if (oldNativeWorld == nativeWorld) deletePositions = CollectionUtils.filter(positions,newPositions);
+        if (oldNativeWorld == nativeWorld)
+            deletePositions = CollectionUtils.filter(positions, newPositions);
         for (int i = 0, deletePositionsSize = deletePositions.size(); i < deletePositionsSize; i++) {
             BlockPosition position = deletePositions.get(i);
             setBlockFast(oldNativeWorld, position, Blocks.AIR.getBlockData());
@@ -222,7 +232,7 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Nullable
-    private TileEntity removeTileEntity(@NotNull World world, @NotNull BlockPosition position){
+    private TileEntity removeTileEntity(@NotNull World world, @NotNull BlockPosition position) {
         return world.getChunkAtWorldCoords(position).tileEntities.remove(position);
     }
 
@@ -231,44 +241,45 @@ public class IWorldHandler extends WorldHandler {
         return new BlockPosition(loc.getX(), loc.getY(), loc.getZ());
     }
 
-    private void setBlockFast(@NotNull World world, @NotNull BlockPosition position,@NotNull IBlockData data) {
+    private void setBlockFast(@NotNull World world, @NotNull BlockPosition position, @NotNull IBlockData data) {
         Chunk chunk = world.getChunkAtWorldCoords(position);
-        ChunkSection chunkSection = chunk.getSections()[position.getY()>>4];
+        ChunkSection chunkSection = chunk.getSections()[position.getY() >> 4];
         if (chunkSection == null) {
             // Put a GLASS block to initialize the section. It will be replaced next with the real block.
             chunk.setType(position, Blocks.GLASS.getBlockData(), false);
             chunkSection = chunk.getSections()[position.getY() >> 4];
         }
-        if(chunkSection.getType(position.getX()&15, position.getY()&15, position.getZ()&15).equals(data)){
+        if (chunkSection.getType(position.getX() & 15, position.getY() & 15, position.getZ() & 15).equals(data)) {
             //Block is already of correct type and data, don't overwrite
             return;
         }
 
-        chunkSection.setType(position.getX()&15, position.getY()&15, position.getZ()&15, data);
+        chunkSection.setType(position.getX() & 15, position.getY() & 15, position.getZ() & 15, data);
         world.notify(position, data, data, 3);
         var engine = chunk.e();
-        if(engine != null)
+        if (engine != null)
             engine.a(position);
         chunk.markDirty();
     }
 
     @Override
-    public void setBlockFast(@NotNull Location location, @NotNull BlockData data){
+    public void setBlockFast(@NotNull Location location, @NotNull BlockData data) {
         setBlockFast(location, MovecraftRotation.NONE, data);
     }
 
     @Override
     public void setBlockFast(@NotNull Location location, @NotNull MovecraftRotation rotation, @NotNull BlockData data) {
         IBlockData blockData;
-        if(data instanceof CraftBlockData){
+        if (data instanceof CraftBlockData) {
             blockData = ((CraftBlockData) data).getState();
-        } else {
+        }
+        else {
             blockData = (IBlockData) data;
         }
         blockData = blockData.a(ROTATION[rotation.ordinal()]);
-        World world = ((CraftWorld)(location.getWorld())).getHandle();
+        World world = ((CraftWorld) (location.getWorld())).getHandle();
         BlockPosition blockPosition = locationToPosition(bukkit2MovecraftLoc(location));
-        setBlockFast(world,blockPosition,blockData);
+        setBlockFast(world, blockPosition, blockData);
     }
 
     @Override
@@ -280,11 +291,11 @@ public class IWorldHandler extends WorldHandler {
         return new MovecraftLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
     }
 
-    private void moveTileEntity(@NotNull World nativeWorld, @NotNull BlockPosition newPosition, @NotNull TileEntity tile){
+    private void moveTileEntity(@NotNull World nativeWorld, @NotNull BlockPosition newPosition, @NotNull TileEntity tile) {
         Chunk chunk = nativeWorld.getChunkAtWorldCoords(newPosition);
         tile.invalidateBlockCache();
         tile.setLocation(nativeWorld, newPosition);
-        if(nativeWorld.captureBlockStates) {
+        if (nativeWorld.captureBlockStates) {
             tile.setLocation(nativeWorld, newPosition);
             nativeWorld.capturedTileEntities.put(newPosition, tile);
             return;
@@ -292,13 +303,15 @@ public class IWorldHandler extends WorldHandler {
         chunk.tileEntities.put(newPosition, tile);
     }
 
-    private class TileHolder{
-        @NotNull private final TileEntity tile;
+    private class TileHolder {
+        @NotNull
+        private final TileEntity tile;
         @Nullable
         private final NextTickListEntry<?> nextTick;
-        @NotNull private final BlockPosition tilePosition;
+        @NotNull
+        private final BlockPosition tilePosition;
 
-        public TileHolder(@NotNull TileEntity tile, @Nullable NextTickListEntry<?> nextTick, @NotNull BlockPosition tilePosition){
+        public TileHolder(@NotNull TileEntity tile, @Nullable NextTickListEntry<?> nextTick, @NotNull BlockPosition tilePosition) {
             this.tile = tile;
             this.nextTick = nextTick;
             this.tilePosition = tilePosition;

--- a/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
+++ b/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
@@ -23,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,25 +36,31 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class IWorldHandler extends WorldHandler {
     private static final Rotation ROTATION[];
+
     static {
         ROTATION = new Rotation[3];
         ROTATION[MovecraftRotation.NONE.ordinal()] = Rotation.NONE;
         ROTATION[MovecraftRotation.CLOCKWISE.ordinal()] = Rotation.CLOCKWISE_90;
         ROTATION[MovecraftRotation.ANTICLOCKWISE.ordinal()] = Rotation.COUNTERCLOCKWISE_90;
     }
+
     private final NextTickProvider tickProvider = new NextTickProvider();
 
-    public IWorldHandler() {}
+    public IWorldHandler() {
+        String mappings = ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion();
+        if (!mappings.equals("f0e3dfc7390de285a4693518dd5bd126"))
+            throw new IllegalStateException("Movecraft is not compatible with this version of Minecraft 1.17: " + mappings);
+    }
 
     @Override
     public void rotateCraft(@NotNull Craft craft, @NotNull MovecraftLocation originPoint, @NotNull MovecraftRotation rotation) {
         //*******************************************
         //*      Step one: Convert to Positions     *
         //*******************************************
-        HashMap<BlockPos,BlockPos> rotatedPositions = new HashMap<>();
+        HashMap<BlockPos, BlockPos> rotatedPositions = new HashMap<>();
         MovecraftRotation counterRotation = rotation == MovecraftRotation.CLOCKWISE ? MovecraftRotation.ANTICLOCKWISE : MovecraftRotation.CLOCKWISE;
-        for(MovecraftLocation newLocation : craft.getHitBox()){
-            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)),locationToPosition(newLocation));
+        for (MovecraftLocation newLocation : craft.getHitBox()) {
+            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)), locationToPosition(newLocation));
         }
         //*******************************************
         //*         Step two: Get the tiles         *
@@ -61,14 +68,14 @@ public class IWorldHandler extends WorldHandler {
         ServerLevel nativeWorld = ((CraftWorld) craft.getWorld()).getHandle();
         List<TileHolder> tiles = new ArrayList<>();
         //get the tiles
-        for(BlockPos position : rotatedPositions.keySet()){
+        for (BlockPos position : rotatedPositions.keySet()) {
             //BlockEntity tile = nativeWorld.removeBlockEntity(position);
-            BlockEntity tile = removeBlockEntity(nativeWorld,position);
-            if(tile == null)
+            BlockEntity tile = removeBlockEntity(nativeWorld, position);
+            if (tile == null)
                 continue;
 //            tile.a(ROTATION[rotation.ordinal()]);
             //get the nextTick to move with the tile
-            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld,position), position));
+            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld, position), position));
         }
 
         //*******************************************
@@ -80,11 +87,11 @@ public class IWorldHandler extends WorldHandler {
         //TODO: Don't move unnecessary blocks
         //get the blocks and rotate them
         HashMap<BlockPos, BlockState> blockData = new HashMap<>();
-        for(BlockPos position : rotatedPositions.keySet()){
-            blockData.put(position,nativeWorld.getBlockState(position).rotate(ROTATION[rotation.ordinal()]));
+        for (BlockPos position : rotatedPositions.keySet()) {
+            blockData.put(position, nativeWorld.getBlockState(position).rotate(ROTATION[rotation.ordinal()]));
         }
         //create the new block
-        for(Map.Entry<BlockPos,BlockState> entry : blockData.entrySet()) {
+        for (Map.Entry<BlockPos, BlockState> entry : blockData.entrySet()) {
             setBlockFast(nativeWorld, rotatedPositions.get(entry.getKey()), entry.getValue());
         }
 
@@ -93,20 +100,20 @@ public class IWorldHandler extends WorldHandler {
         //*    Step four: replace all the tiles     *
         //*******************************************
         //TODO: go by chunks
-        for(TileHolder tileHolder : tiles){
-            moveBlockEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()),tileHolder.getTile());
-            if(tileHolder.getNextTick()==null)
+        for (TileHolder tileHolder : tiles) {
+            moveBlockEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()), tileHolder.getTile());
+            if (tileHolder.getNextTick() == null)
                 continue;
             final long currentTime = nativeWorld.E.getGameTime();
-            nativeWorld.getBlockTickList().scheduleTick(rotatedPositions.get(tileHolder.getNextTick().pos), (Block)tileHolder.getNextTick().getType(), (int) (tileHolder.getNextTick().triggerTick - currentTime), tileHolder.getNextTick().priority);
+            nativeWorld.getBlockTickList().scheduleTick(rotatedPositions.get(tileHolder.getNextTick().pos), (Block) tileHolder.getNextTick().getType(), (int) (tileHolder.getNextTick().triggerTick - currentTime), tileHolder.getNextTick().priority);
         }
 
         //*******************************************
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         //TODO: add support for pass-through
-        Collection<BlockPos> deletePositions =  CollectionUtils.filter(rotatedPositions.keySet(),rotatedPositions.values());
-        for(BlockPos position : deletePositions){
+        Collection<BlockPos> deletePositions = CollectionUtils.filter(rotatedPositions.keySet(), rotatedPositions.values());
+        for (BlockPos position : deletePositions) {
             setBlockFast(nativeWorld, position, Blocks.AIR.defaultBlockState());
         }
     }
@@ -159,7 +166,7 @@ public class IWorldHandler extends WorldHandler {
             newPositions.add(position.f(translateVector));
         }
         //create the new block
-        for(int i = 0, positionSize = newPositions.size(); i<positionSize; i++) {
+        for (int i = 0, positionSize = newPositions.size(); i < positionSize; i++) {
             setBlockFast(nativeWorld, newPositions.get(i), blockData.get(i));
         }
         //*******************************************
@@ -178,7 +185,8 @@ public class IWorldHandler extends WorldHandler {
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         List<BlockPos> deletePositions = positions;
-        if (oldNativeWorld == nativeWorld) deletePositions = CollectionUtils.filter(positions,newPositions);
+        if (oldNativeWorld == nativeWorld)
+            deletePositions = CollectionUtils.filter(positions, newPositions);
         for (int i = 0, deletePositionsSize = deletePositions.size(); i < deletePositionsSize; i++) {
             BlockPos position = deletePositions.get(i);
             setBlockFast(oldNativeWorld, position, Blocks.AIR.defaultBlockState());
@@ -186,7 +194,7 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Nullable
-    private BlockEntity removeBlockEntity(@NotNull Level world, @NotNull BlockPos position){
+    private BlockEntity removeBlockEntity(@NotNull Level world, @NotNull BlockPos position) {
         return world.getChunkAt(position).blockEntities.remove(position);
     }
 
@@ -195,7 +203,7 @@ public class IWorldHandler extends WorldHandler {
         return new BlockPos(loc.getX(), loc.getY(), loc.getZ());
     }
 
-    private void setBlockFast(@NotNull Level world, @NotNull BlockPos position,@NotNull BlockState data) {
+    private void setBlockFast(@NotNull Level world, @NotNull BlockPos position, @NotNull BlockState data) {
         LevelChunk chunk = world.getChunkAt(position);
         int chunkSection = (position.getY() >> 4) - chunk.getMinSection();
         LevelChunkSection section = chunk.getSections()[chunkSection];
@@ -204,33 +212,34 @@ public class IWorldHandler extends WorldHandler {
             chunk.setBlockState(position, Blocks.GLASS.defaultBlockState(), false);
             section = chunk.getSections()[chunkSection];
         }
-        if(section.getBlockState(position.getX()&15, position.getY()&15, position.getZ()&15).equals(data)){
+        if (section.getBlockState(position.getX() & 15, position.getY() & 15, position.getZ() & 15).equals(data)) {
             //Block is already of correct type and data, don't overwrite
             return;
         }
-        section.setBlockState(position.getX()&15, position.getY()&15, position.getZ()&15, data);
+        section.setBlockState(position.getX() & 15, position.getY() & 15, position.getZ() & 15, data);
         world.sendBlockUpdated(position, data, data, 3);
         world.getLightEngine().checkBlock(position); // boolean corresponds to if chunk section empty
         chunk.markUnsaved();
     }
 
     @Override
-    public void setBlockFast(@NotNull Location location, @NotNull BlockData data){
+    public void setBlockFast(@NotNull Location location, @NotNull BlockData data) {
         setBlockFast(location, MovecraftRotation.NONE, data);
     }
 
     @Override
     public void setBlockFast(@NotNull Location location, @NotNull MovecraftRotation rotation, @NotNull BlockData data) {
         BlockState blockData;
-        if(data instanceof CraftBlockData){
+        if (data instanceof CraftBlockData) {
             blockData = ((CraftBlockData) data).getState();
-        } else {
+        }
+        else {
             blockData = (BlockState) data;
         }
         blockData = blockData.rotate(ROTATION[rotation.ordinal()]);
-        Level world = ((CraftWorld)(location.getWorld())).getHandle();
+        Level world = ((CraftWorld) (location.getWorld())).getHandle();
         BlockPos BlockPos = locationToPosition(MathUtils.bukkit2MovecraftLoc(location));
-        setBlockFast(world,BlockPos,blockData);
+        setBlockFast(world, BlockPos, blockData);
     }
 
     @Override
@@ -238,17 +247,18 @@ public class IWorldHandler extends WorldHandler {
         // Disabled
     }
 
-    private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile){
+    private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {
         LevelChunk chunk = nativeWorld.getChunkAt(newPosition);
         try {
             var positionField = BlockEntity.class.getDeclaredField("o"); // o is obfuscated worldPosition
             UnsafeUtils.setField(positionField, tile, newPosition);
-        } catch (NoSuchFieldException e) {
+        }
+        catch (NoSuchFieldException e) {
             e.printStackTrace();
         }
         tile.setLevel(nativeWorld);
         tile.clearRemoved();
-        if(nativeWorld.captureBlockStates) {
+        if (nativeWorld.captureBlockStates) {
             nativeWorld.capturedTileEntities.put(newPosition, tile);
             return;
         }
@@ -256,13 +266,15 @@ public class IWorldHandler extends WorldHandler {
         chunk.blockEntities.put(newPosition, tile);
     }
 
-    private static class TileHolder{
-        @NotNull private final BlockEntity tile;
+    private static class TileHolder {
+        @NotNull
+        private final BlockEntity tile;
         @Nullable
         private final TickNextTickData<?> nextTick;
-        @NotNull private final BlockPos tilePosition;
+        @NotNull
+        private final BlockPos tilePosition;
 
-        public TileHolder(@NotNull BlockEntity tile, @Nullable TickNextTickData<?> nextTick, @NotNull BlockPos tilePosition){
+        public TileHolder(@NotNull BlockEntity tile, @Nullable TickNextTickData<?> nextTick, @NotNull BlockPos tilePosition) {
             this.tile = tile;
             this.nextTick = nextTick;
             this.tilePosition = tilePosition;

--- a/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
+++ b/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
@@ -23,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,15 +36,21 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class IWorldHandler extends WorldHandler {
     private static final Rotation ROTATION[];
+
     static {
         ROTATION = new Rotation[3];
         ROTATION[MovecraftRotation.NONE.ordinal()] = Rotation.NONE;
         ROTATION[MovecraftRotation.CLOCKWISE.ordinal()] = Rotation.CLOCKWISE_90;
         ROTATION[MovecraftRotation.ANTICLOCKWISE.ordinal()] = Rotation.COUNTERCLOCKWISE_90;
     }
+
     private final NextTickProvider tickProvider = new NextTickProvider();
 
-    public IWorldHandler() {}
+    public IWorldHandler() {
+        String mappings = ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion();
+        if (!mappings.equals("eaeedbff51b16ead3170906872fda334"))
+            throw new IllegalStateException("Movecraft is not compatible with this version of Minecraft 1.18: " + mappings);
+    }
 
 //    @Override
 //    public void addPlayerLocation(Player player, double x, double y, double z, float yaw, float pitch){
@@ -56,10 +63,10 @@ public class IWorldHandler extends WorldHandler {
         //*******************************************
         //*      Step one: Convert to Positions     *
         //*******************************************
-        HashMap<BlockPos,BlockPos> rotatedPositions = new HashMap<>();
+        HashMap<BlockPos, BlockPos> rotatedPositions = new HashMap<>();
         MovecraftRotation counterRotation = rotation == MovecraftRotation.CLOCKWISE ? MovecraftRotation.ANTICLOCKWISE : MovecraftRotation.CLOCKWISE;
-        for(MovecraftLocation newLocation : craft.getHitBox()){
-            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)),locationToPosition(newLocation));
+        for (MovecraftLocation newLocation : craft.getHitBox()) {
+            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)), locationToPosition(newLocation));
         }
         //*******************************************
         //*         Step two: Get the tiles         *
@@ -67,14 +74,14 @@ public class IWorldHandler extends WorldHandler {
         ServerLevel nativeWorld = ((CraftWorld) craft.getWorld()).getHandle();
         List<TileHolder> tiles = new ArrayList<>();
         //get the tiles
-        for(BlockPos position : rotatedPositions.keySet()){
+        for (BlockPos position : rotatedPositions.keySet()) {
             //BlockEntity tile = nativeWorld.removeBlockEntity(position);
-            BlockEntity tile = removeBlockEntity(nativeWorld,position);
-            if(tile == null)
+            BlockEntity tile = removeBlockEntity(nativeWorld, position);
+            if (tile == null)
                 continue;
 //            tile.a(ROTATION[rotation.ordinal()]);
             //get the nextTick to move with the tile
-            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld,position), position));
+            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld, position), position));
         }
 
         //*******************************************
@@ -86,11 +93,11 @@ public class IWorldHandler extends WorldHandler {
         //TODO: Don't move unnecessary blocks
         //get the blocks and rotate them
         HashMap<BlockPos, BlockState> blockData = new HashMap<>();
-        for(BlockPos position : rotatedPositions.keySet()){
-            blockData.put(position,nativeWorld.getBlockState(position).rotate(ROTATION[rotation.ordinal()]));
+        for (BlockPos position : rotatedPositions.keySet()) {
+            blockData.put(position, nativeWorld.getBlockState(position).rotate(ROTATION[rotation.ordinal()]));
         }
         //create the new block
-        for(Map.Entry<BlockPos,BlockState> entry : blockData.entrySet()) {
+        for (Map.Entry<BlockPos, BlockState> entry : blockData.entrySet()) {
             setBlockFast(nativeWorld, rotatedPositions.get(entry.getKey()), entry.getValue());
         }
 
@@ -99,20 +106,20 @@ public class IWorldHandler extends WorldHandler {
         //*    Step four: replace all the tiles     *
         //*******************************************
         //TODO: go by chunks
-        for(TileHolder tileHolder : tiles){
-            moveBlockEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()),tileHolder.getTile());
-            if(tileHolder.getNextTick()==null)
+        for (TileHolder tileHolder : tiles) {
+            moveBlockEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()), tileHolder.getTile());
+            if (tileHolder.getNextTick() == null)
                 continue;
             final long currentTime = nativeWorld.M.getGameTime();
-            nativeWorld.getBlockTicks().schedule( new ScheduledTick<>((Block) tileHolder.getNextTick().type(), rotatedPositions.get(tileHolder.getNextTick().pos()), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
+            nativeWorld.getBlockTicks().schedule(new ScheduledTick<>((Block) tileHolder.getNextTick().type(), rotatedPositions.get(tileHolder.getNextTick().pos()), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
         }
 
         //*******************************************
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         //TODO: add support for pass-through
-        Collection<BlockPos> deletePositions =  CollectionUtils.filter(rotatedPositions.keySet(),rotatedPositions.values());
-        for(BlockPos position : deletePositions){
+        Collection<BlockPos> deletePositions = CollectionUtils.filter(rotatedPositions.keySet(), rotatedPositions.values());
+        for (BlockPos position : deletePositions) {
             setBlockFast(nativeWorld, position, Blocks.AIR.defaultBlockState());
         }
     }
@@ -165,7 +172,7 @@ public class IWorldHandler extends WorldHandler {
             newPositions.add(position.offset(translateVector));
         }
         //create the new block
-        for(int i = 0, positionSize = newPositions.size(); i<positionSize; i++) {
+        for (int i = 0, positionSize = newPositions.size(); i < positionSize; i++) {
             setBlockFast(nativeWorld, newPositions.get(i), blockData.get(i));
         }
         //*******************************************
@@ -178,13 +185,14 @@ public class IWorldHandler extends WorldHandler {
             if (tileHolder.getNextTick() == null)
                 continue;
             final long currentTime = nativeWorld.getGameTime();
-            nativeWorld.getBlockTicks().schedule( new ScheduledTick<>((Block) tileHolder.getNextTick().type(), tileHolder.getTilePosition().offset(translateVector), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
+            nativeWorld.getBlockTicks().schedule(new ScheduledTick<>((Block) tileHolder.getNextTick().type(), tileHolder.getTilePosition().offset(translateVector), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
         }
         //*******************************************
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         List<BlockPos> deletePositions = positions;
-        if (oldNativeWorld == nativeWorld) deletePositions = CollectionUtils.filter(positions,newPositions);
+        if (oldNativeWorld == nativeWorld)
+            deletePositions = CollectionUtils.filter(positions, newPositions);
         for (int i = 0, deletePositionsSize = deletePositions.size(); i < deletePositionsSize; i++) {
             BlockPos position = deletePositions.get(i);
             setBlockFast(oldNativeWorld, position, Blocks.AIR.defaultBlockState());
@@ -192,7 +200,7 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Nullable
-    private BlockEntity removeBlockEntity(@NotNull Level world, @NotNull BlockPos position){
+    private BlockEntity removeBlockEntity(@NotNull Level world, @NotNull BlockPos position) {
         return world.getChunkAt(position).blockEntities.remove(position);
     }
 
@@ -201,7 +209,7 @@ public class IWorldHandler extends WorldHandler {
         return new BlockPos(loc.getX(), loc.getY(), loc.getZ());
     }
 
-    private void setBlockFast(@NotNull Level world, @NotNull BlockPos position,@NotNull BlockState data) {
+    private void setBlockFast(@NotNull Level world, @NotNull BlockPos position, @NotNull BlockState data) {
         LevelChunk chunk = world.getChunkAt(position);
         int chunkSection = (position.getY() >> 4) - chunk.getMinSection();
         LevelChunkSection section = chunk.getSections()[chunkSection];
@@ -210,33 +218,34 @@ public class IWorldHandler extends WorldHandler {
             chunk.setBlockState(position, Blocks.GLASS.defaultBlockState(), false);
             section = chunk.getSections()[chunkSection];
         }
-        if(section.getBlockState(position.getX()&15, position.getY()&15, position.getZ()&15).equals(data)){
+        if (section.getBlockState(position.getX() & 15, position.getY() & 15, position.getZ() & 15).equals(data)) {
             //Block is already of correct type and data, don't overwrite
             return;
         }
-        section.setBlockState(position.getX()&15, position.getY()&15, position.getZ()&15, data);
+        section.setBlockState(position.getX() & 15, position.getY() & 15, position.getZ() & 15, data);
         world.sendBlockUpdated(position, data, data, 3);
         world.getLightEngine().checkBlock(position); // boolean corresponds to if chunk section empty
         chunk.setUnsaved(true);
     }
 
     @Override
-    public void setBlockFast(@NotNull Location location, @NotNull BlockData data){
+    public void setBlockFast(@NotNull Location location, @NotNull BlockData data) {
         setBlockFast(location, MovecraftRotation.NONE, data);
     }
 
     @Override
     public void setBlockFast(@NotNull Location location, @NotNull MovecraftRotation rotation, @NotNull BlockData data) {
         BlockState blockData;
-        if(data instanceof CraftBlockData){
+        if (data instanceof CraftBlockData) {
             blockData = ((CraftBlockData) data).getState();
-        } else {
+        }
+        else {
             blockData = (BlockState) data;
         }
         blockData = blockData.rotate(ROTATION[rotation.ordinal()]);
-        Level world = ((CraftWorld)(location.getWorld())).getHandle();
+        Level world = ((CraftWorld) (location.getWorld())).getHandle();
         BlockPos BlockPos = locationToPosition(MathUtils.bukkit2MovecraftLoc(location));
-        setBlockFast(world,BlockPos,blockData);
+        setBlockFast(world, BlockPos, blockData);
     }
 
     @Override
@@ -244,17 +253,18 @@ public class IWorldHandler extends WorldHandler {
         // Disabled
     }
 
-    private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile){
+    private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {
         LevelChunk chunk = nativeWorld.getChunkAt(newPosition);
         try {
             var positionField = BlockEntity.class.getDeclaredField("o"); // o is obfuscated worldPosition
             UnsafeUtils.setField(positionField, tile, newPosition);
-        } catch (NoSuchFieldException e) {
+        }
+        catch (NoSuchFieldException e) {
             e.printStackTrace();
         }
         tile.setLevel(nativeWorld);
         tile.clearRemoved();
-        if(nativeWorld.captureBlockStates) {
+        if (nativeWorld.captureBlockStates) {
             nativeWorld.capturedTileEntities.put(newPosition, tile);
             return;
         }
@@ -262,13 +272,15 @@ public class IWorldHandler extends WorldHandler {
         chunk.blockEntities.put(newPosition, tile);
     }
 
-    private static class TileHolder{
-        @NotNull private final BlockEntity tile;
+    private static class TileHolder {
+        @NotNull
+        private final BlockEntity tile;
         @Nullable
         private final ScheduledTick<?> nextTick;
-        @NotNull private final BlockPos tilePosition;
+        @NotNull
+        private final BlockPos tilePosition;
 
-        public TileHolder(@NotNull BlockEntity tile, @Nullable ScheduledTick<?> nextTick, @NotNull BlockPos tilePosition){
+        public TileHolder(@NotNull BlockEntity tile, @Nullable ScheduledTick<?> nextTick, @NotNull BlockPos tilePosition) {
             this.tile = tile;
             this.nextTick = nextTick;
             this.tilePosition = tilePosition;

--- a/modules/v1_19_R1/pom.xml
+++ b/modules/v1_19_R1/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19.1-R0.1-SNAPSHOT</version>
+            <version>1.19.2-R0.1-SNAPSHOT</version>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
         </dependency>
@@ -67,9 +67,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.19.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.19.2-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.19.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.19.2-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -82,8 +82,8 @@
                         <id>remap-spigot</id>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.19.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.19.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.19.2-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.19.2-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/modules/v1_19_R1/src/main/java/net/countercraft/movecraft/compat/v1_19_R1/IWorldHandler.java
+++ b/modules/v1_19_R1/src/main/java/net/countercraft/movecraft/compat/v1_19_R1/IWorldHandler.java
@@ -48,7 +48,7 @@ public class IWorldHandler extends WorldHandler {
 
     public IWorldHandler() {
         String mappings = ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion();
-        if (!mappings.equals("4cc0cc97cac491651bff3af8b124a214"))
+        if (!mappings.equals("69c84c88aeb92ce9fa9525438b93f4fe"))
             throw new IllegalStateException("Movecraft is not compatible with this version of Minecraft 1.19: " + mappings);
     }
 

--- a/modules/v1_19_R1/src/main/java/net/countercraft/movecraft/compat/v1_19_R1/IWorldHandler.java
+++ b/modules/v1_19_R1/src/main/java/net/countercraft/movecraft/compat/v1_19_R1/IWorldHandler.java
@@ -23,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_19_R1.util.CraftMagicNumbers;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,15 +36,21 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class IWorldHandler extends WorldHandler {
     private static final Rotation ROTATION[];
+
     static {
         ROTATION = new Rotation[3];
         ROTATION[MovecraftRotation.NONE.ordinal()] = Rotation.NONE;
         ROTATION[MovecraftRotation.CLOCKWISE.ordinal()] = Rotation.CLOCKWISE_90;
         ROTATION[MovecraftRotation.ANTICLOCKWISE.ordinal()] = Rotation.COUNTERCLOCKWISE_90;
     }
+
     private final NextTickProvider tickProvider = new NextTickProvider();
 
-    public IWorldHandler() {}
+    public IWorldHandler() {
+        String mappings = ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion();
+        if (!mappings.equals("4cc0cc97cac491651bff3af8b124a214"))
+            throw new IllegalStateException("Movecraft is not compatible with this version of Minecraft 1.19: " + mappings);
+    }
 
 //    @Override
 //    public void addPlayerLocation(Player player, double x, double y, double z, float yaw, float pitch){
@@ -56,10 +63,10 @@ public class IWorldHandler extends WorldHandler {
         //*******************************************
         //*      Step one: Convert to Positions     *
         //*******************************************
-        HashMap<BlockPos,BlockPos> rotatedPositions = new HashMap<>();
+        HashMap<BlockPos, BlockPos> rotatedPositions = new HashMap<>();
         MovecraftRotation counterRotation = rotation == MovecraftRotation.CLOCKWISE ? MovecraftRotation.ANTICLOCKWISE : MovecraftRotation.CLOCKWISE;
-        for(MovecraftLocation newLocation : craft.getHitBox()){
-            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)),locationToPosition(newLocation));
+        for (MovecraftLocation newLocation : craft.getHitBox()) {
+            rotatedPositions.put(locationToPosition(MathUtils.rotateVec(counterRotation, newLocation.subtract(originPoint)).add(originPoint)), locationToPosition(newLocation));
         }
         //*******************************************
         //*         Step two: Get the tiles         *
@@ -67,14 +74,14 @@ public class IWorldHandler extends WorldHandler {
         ServerLevel nativeWorld = ((CraftWorld) craft.getWorld()).getHandle();
         List<TileHolder> tiles = new ArrayList<>();
         //get the tiles
-        for(BlockPos position : rotatedPositions.keySet()){
+        for (BlockPos position : rotatedPositions.keySet()) {
             //BlockEntity tile = nativeWorld.removeBlockEntity(position);
-            BlockEntity tile = removeBlockEntity(nativeWorld,position);
-            if(tile == null)
+            BlockEntity tile = removeBlockEntity(nativeWorld, position);
+            if (tile == null)
                 continue;
 //            tile.a(ROTATION[rotation.ordinal()]);
             //get the nextTick to move with the tile
-            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld,position), position));
+            tiles.add(new TileHolder(tile, tickProvider.getNextTick(nativeWorld, position), position));
         }
 
         //*******************************************
@@ -86,11 +93,11 @@ public class IWorldHandler extends WorldHandler {
         //TODO: Don't move unnecessary blocks
         //get the blocks and rotate them
         HashMap<BlockPos, BlockState> blockData = new HashMap<>();
-        for(BlockPos position : rotatedPositions.keySet()){
-            blockData.put(position,nativeWorld.getBlockState(position).rotate(ROTATION[rotation.ordinal()]));
+        for (BlockPos position : rotatedPositions.keySet()) {
+            blockData.put(position, nativeWorld.getBlockState(position).rotate(ROTATION[rotation.ordinal()]));
         }
         //create the new block
-        for(Map.Entry<BlockPos,BlockState> entry : blockData.entrySet()) {
+        for (Map.Entry<BlockPos, BlockState> entry : blockData.entrySet()) {
             setBlockFast(nativeWorld, rotatedPositions.get(entry.getKey()), entry.getValue());
         }
 
@@ -99,20 +106,20 @@ public class IWorldHandler extends WorldHandler {
         //*    Step four: replace all the tiles     *
         //*******************************************
         //TODO: go by chunks
-        for(TileHolder tileHolder : tiles){
-            moveBlockEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()),tileHolder.getTile());
-            if(tileHolder.getNextTick()==null)
+        for (TileHolder tileHolder : tiles) {
+            moveBlockEntity(nativeWorld, rotatedPositions.get(tileHolder.getTilePosition()), tileHolder.getTile());
+            if (tileHolder.getNextTick() == null)
                 continue;
             final long currentTime = nativeWorld.N.getGameTime();
-            nativeWorld.getBlockTicks().schedule( new ScheduledTick<>((Block) tileHolder.getNextTick().type(), rotatedPositions.get(tileHolder.getNextTick().pos()), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
+            nativeWorld.getBlockTicks().schedule(new ScheduledTick<>((Block) tileHolder.getNextTick().type(), rotatedPositions.get(tileHolder.getNextTick().pos()), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
         }
 
         //*******************************************
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         //TODO: add support for pass-through
-        Collection<BlockPos> deletePositions =  CollectionUtils.filter(rotatedPositions.keySet(),rotatedPositions.values());
-        for(BlockPos position : deletePositions){
+        Collection<BlockPos> deletePositions = CollectionUtils.filter(rotatedPositions.keySet(), rotatedPositions.values());
+        for (BlockPos position : deletePositions) {
             setBlockFast(nativeWorld, position, Blocks.AIR.defaultBlockState());
         }
     }
@@ -165,7 +172,7 @@ public class IWorldHandler extends WorldHandler {
             newPositions.add(position.offset(translateVector));
         }
         //create the new block
-        for(int i = 0, positionSize = newPositions.size(); i<positionSize; i++) {
+        for (int i = 0, positionSize = newPositions.size(); i < positionSize; i++) {
             setBlockFast(nativeWorld, newPositions.get(i), blockData.get(i));
         }
         //*******************************************
@@ -178,13 +185,14 @@ public class IWorldHandler extends WorldHandler {
             if (tileHolder.getNextTick() == null)
                 continue;
             final long currentTime = nativeWorld.getGameTime();
-            nativeWorld.getBlockTicks().schedule( new ScheduledTick<>((Block) tileHolder.getNextTick().type(), tileHolder.getTilePosition().offset(translateVector), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
+            nativeWorld.getBlockTicks().schedule(new ScheduledTick<>((Block) tileHolder.getNextTick().type(), tileHolder.getTilePosition().offset(translateVector), tileHolder.getNextTick().triggerTick() - currentTime, tileHolder.getNextTick().priority(), tileHolder.getNextTick().subTickOrder()));
         }
         //*******************************************
         //*   Step five: Destroy the leftovers      *
         //*******************************************
         List<BlockPos> deletePositions = positions;
-        if (oldNativeWorld == nativeWorld) deletePositions = CollectionUtils.filter(positions,newPositions);
+        if (oldNativeWorld == nativeWorld)
+            deletePositions = CollectionUtils.filter(positions, newPositions);
         for (int i = 0, deletePositionsSize = deletePositions.size(); i < deletePositionsSize; i++) {
             BlockPos position = deletePositions.get(i);
             setBlockFast(oldNativeWorld, position, Blocks.AIR.defaultBlockState());
@@ -192,7 +200,7 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Nullable
-    private BlockEntity removeBlockEntity(@NotNull Level world, @NotNull BlockPos position){
+    private BlockEntity removeBlockEntity(@NotNull Level world, @NotNull BlockPos position) {
         return world.getChunkAt(position).blockEntities.remove(position);
     }
 
@@ -201,7 +209,7 @@ public class IWorldHandler extends WorldHandler {
         return new BlockPos(loc.getX(), loc.getY(), loc.getZ());
     }
 
-    private void setBlockFast(@NotNull Level world, @NotNull BlockPos position,@NotNull BlockState data) {
+    private void setBlockFast(@NotNull Level world, @NotNull BlockPos position, @NotNull BlockState data) {
         LevelChunk chunk = world.getChunkAt(position);
         int chunkSection = (position.getY() >> 4) - chunk.getMinSection();
         LevelChunkSection section = chunk.getSections()[chunkSection];
@@ -210,33 +218,34 @@ public class IWorldHandler extends WorldHandler {
             chunk.setBlockState(position, Blocks.GLASS.defaultBlockState(), false);
             section = chunk.getSections()[chunkSection];
         }
-        if(section.getBlockState(position.getX()&15, position.getY()&15, position.getZ()&15).equals(data)){
+        if (section.getBlockState(position.getX() & 15, position.getY() & 15, position.getZ() & 15).equals(data)) {
             //Block is already of correct type and data, don't overwrite
             return;
         }
-        section.setBlockState(position.getX()&15, position.getY()&15, position.getZ()&15, data);
+        section.setBlockState(position.getX() & 15, position.getY() & 15, position.getZ() & 15, data);
         world.sendBlockUpdated(position, data, data, 3);
         world.getLightEngine().checkBlock(position); // boolean corresponds to if chunk section empty
         chunk.setUnsaved(true);
     }
 
     @Override
-    public void setBlockFast(@NotNull Location location, @NotNull BlockData data){
+    public void setBlockFast(@NotNull Location location, @NotNull BlockData data) {
         setBlockFast(location, MovecraftRotation.NONE, data);
     }
 
     @Override
     public void setBlockFast(@NotNull Location location, @NotNull MovecraftRotation rotation, @NotNull BlockData data) {
         BlockState blockData;
-        if(data instanceof CraftBlockData){
+        if (data instanceof CraftBlockData) {
             blockData = ((CraftBlockData) data).getState();
-        } else {
+        }
+        else {
             blockData = (BlockState) data;
         }
         blockData = blockData.rotate(ROTATION[rotation.ordinal()]);
-        Level world = ((CraftWorld)(location.getWorld())).getHandle();
+        Level world = ((CraftWorld) (location.getWorld())).getHandle();
         BlockPos BlockPos = locationToPosition(MathUtils.bukkit2MovecraftLoc(location));
-        setBlockFast(world,BlockPos,blockData);
+        setBlockFast(world, BlockPos, blockData);
     }
 
     @Override
@@ -244,17 +253,18 @@ public class IWorldHandler extends WorldHandler {
         // Disabled
     }
 
-    private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile){
+    private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {
         LevelChunk chunk = nativeWorld.getChunkAt(newPosition);
         try {
             var positionField = BlockEntity.class.getDeclaredField("o"); // o is obfuscated worldPosition
             UnsafeUtils.setField(positionField, tile, newPosition);
-        } catch (NoSuchFieldException e) {
+        }
+        catch (NoSuchFieldException e) {
             e.printStackTrace();
         }
         tile.setLevel(nativeWorld);
         tile.clearRemoved();
-        if(nativeWorld.captureBlockStates) {
+        if (nativeWorld.captureBlockStates) {
             nativeWorld.capturedTileEntities.put(newPosition, tile);
             return;
         }
@@ -262,13 +272,15 @@ public class IWorldHandler extends WorldHandler {
         chunk.blockEntities.put(newPosition, tile);
     }
 
-    private static class TileHolder{
-        @NotNull private final BlockEntity tile;
+    private static class TileHolder {
+        @NotNull
+        private final BlockEntity tile;
         @Nullable
         private final ScheduledTick<?> nextTick;
-        @NotNull private final BlockPos tilePosition;
+        @NotNull
+        private final BlockPos tilePosition;
 
-        public TileHolder(@NotNull BlockEntity tile, @Nullable ScheduledTick<?> nextTick, @NotNull BlockPos tilePosition){
+        public TileHolder(@NotNull BlockEntity tile, @Nullable ScheduledTick<?> nextTick, @NotNull BlockPos tilePosition) {
             this.tile = tile;
             this.nextTick = nextTick;
             this.tilePosition = tilePosition;

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <url>http://github.com/apdevteam/Movecraft</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>8.0.0-a.8</revision>
+        <revision>8.0.0-a.9-dev</revision>
     </properties>
 
     <modules>


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
Per the recent spigot releases, CraftMagicNumbers.getMappingsVersion() is the proper method to verify the NMS mappings are correct, and prevent 1.19 vs 1.19.2 compatibility problems during loading.  I've now implemented a check in the worldhandler inits to verify the mappings against the developed versions, and fail if incorrect.

In addition, I've updated us to 1.19.2.

### Checklist
- [x] Tested on 1.14.4, 1.16.5, 1.17.1, 1.18.2, and 1.19.2
