### PR TITLE
Reading .properties files with UTF-8 + PropertiesDefaults option + More localisation fields (signs + Cruising action bar message)

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -118,7 +118,7 @@ public class Movecraft extends JavaPlugin {
                 saveResource("localisation/movecraftlang_" + s + ".properties", false);
             }
         }
-        I18nSupport.init();
+        I18nSupport.init(getConfig().getBoolean("UsePropertiesDefaults", false));
 
 
         // if the PilotTool is specified in the config.yml file, use it

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -43,6 +43,15 @@ import java.util.logging.Level;
 import static net.countercraft.movecraft.util.SignUtils.getFacing;
 
 public abstract class BaseCraft implements Craft {
+    private static final String ASCEND_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Ascend");
+    private static final String CRUISE_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Cruise");
+    private static final String DESCEND_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Descend");
+    private static final String ON_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - ON");
+    private static final String OFF_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - OFF");
+    private static final String CRUISING_MAIN_AB_TEXT = I18nSupport.getInternationalisedString("Cruising - Main action bar text");
+    private static final String CRUISING_ENABLED_AB_TEXT = I18nSupport.getInternationalisedString("Cruising - Enabled action bar text");
+    private static final String CRUISING_DISABLED_AB_TEXT = I18nSupport.getInternationalisedString("Cruising - Disabled action bar text");
+
     @NotNull
     protected final CraftType type;
     @NotNull
@@ -240,27 +249,27 @@ public abstract class BaseCraft implements Craft {
             if (sign.equals(clicked)) {
                 continue;
             }
-            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: ON")) {
-                sign.setLine(0, "Cruise: OFF");
+            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(CRUISE_SIGN_TEXT + ON_SIGN_TEXT)) {
+                sign.setLine(0, CRUISE_SIGN_TEXT + OFF_SIGN_TEXT);
             }
-            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: OFF")
-                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase("Cruise: ON")
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(CRUISE_SIGN_TEXT + OFF_SIGN_TEXT)
+                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase(CRUISE_SIGN_TEXT + ON_SIGN_TEXT)
                     && getFacing(sign) == getFacing(clicked)) {
-                sign.setLine(0, "Cruise: ON");
+                sign.setLine(0, CRUISE_SIGN_TEXT + ON_SIGN_TEXT);
             }
-            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")) {
-                sign.setLine(0, "Ascend: OFF");
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(ASCEND_SIGN_TEXT + ON_SIGN_TEXT)) {
+                sign.setLine(0, ASCEND_SIGN_TEXT + OFF_SIGN_TEXT);
             }
-            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: OFF")
-                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase("Ascend: ON")) {
-                sign.setLine(0, "Ascend: ON");
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(ASCEND_SIGN_TEXT + OFF_SIGN_TEXT)
+                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase(ASCEND_SIGN_TEXT + ON_SIGN_TEXT)) {
+                sign.setLine(0, ASCEND_SIGN_TEXT + ON_SIGN_TEXT);
             }
-            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")) {
-                sign.setLine(0, "Descend: OFF");
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(DESCEND_SIGN_TEXT + ON_SIGN_TEXT)) {
+                sign.setLine(0, DESCEND_SIGN_TEXT + OFF_SIGN_TEXT);
             }
-            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: OFF")
-                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase("Descend: ON")) {
-                sign.setLine(0, "Descend: ON");
+            else if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(DESCEND_SIGN_TEXT + OFF_SIGN_TEXT)
+                    && ChatColor.stripColor(clicked.getLine(0)).equalsIgnoreCase(DESCEND_SIGN_TEXT + ON_SIGN_TEXT)) {
+                sign.setLine(0, DESCEND_SIGN_TEXT + ON_SIGN_TEXT);
             }
             sign.update();
         }
@@ -273,7 +282,8 @@ public abstract class BaseCraft implements Craft {
 
     @Override
     public void setCruising(boolean cruising) {
-        audience.sendActionBar(Component.text().content("Cruising " + (cruising ? "enabled" : "disabled")));
+        audience.sendActionBar(Component.text().content(CRUISING_MAIN_AB_TEXT +
+                (cruising ? CRUISING_ENABLED_AB_TEXT : CRUISING_DISABLED_AB_TEXT)));
         this.cruising = cruising;
     }
 

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/localisation/I18nSupport.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/localisation/I18nSupport.java
@@ -27,6 +27,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.logging.Level;
 
@@ -56,7 +58,7 @@ public class I18nSupport {
         }
 
         try {
-            languageFile.load(is);
+            languageFile.load(new InputStreamReader(is, StandardCharsets.UTF_8));
             is.close();
         } catch (IOException e) {
             e.printStackTrace();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/localisation/I18nSupport.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/localisation/I18nSupport.java
@@ -47,7 +47,7 @@ public class I18nSupport {
             Properties defaultProperies4DefaultProperties = new Properties();
             try {
                 defaultProperies4DefaultProperties.load(new InputStreamReader(
-                        I18nSupport.class.getResourceAsStream("localisation/movecraftlang_en.properties"),
+                        I18nSupport.class.getResourceAsStream("/localisation/movecraftlang_en.properties"),
                         StandardCharsets.UTF_8));
                 defaultProperties = new Properties(defaultProperies4DefaultProperties);
                 defaultProperties.load(new InputStreamReader(

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/localisation/I18nSupport.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/localisation/I18nSupport.java
@@ -35,14 +35,32 @@ import java.util.logging.Level;
 public class I18nSupport {
     private static Properties languageFile;
 
-    public static void init() {
-        languageFile = new Properties();
-
+    public static void init(boolean usePropertiesDefaults) {
         File localisationDirectory = new File(Movecraft.getInstance().getDataFolder().getAbsolutePath() + "/localisation");
 
         if (!localisationDirectory.exists()) {
             localisationDirectory.mkdirs();
         }
+
+        Properties defaultProperties = null;
+        if (usePropertiesDefaults) {
+            Properties defaultProperies4DefaultProperties = new Properties();
+            try {
+                defaultProperies4DefaultProperties.load(new InputStreamReader(
+                        I18nSupport.class.getResourceAsStream("localisation/movecraftlang_en.properties"),
+                        StandardCharsets.UTF_8));
+                defaultProperties = new Properties(defaultProperies4DefaultProperties);
+                defaultProperties.load(new InputStreamReader(
+                        new FileInputStream(localisationDirectory.getAbsolutePath() + "/movecraftlang_en.properties"),
+                        StandardCharsets.UTF_8));
+            } catch (FileNotFoundException e) {
+                defaultProperties = defaultProperies4DefaultProperties;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        languageFile = new Properties(defaultProperties);
 
         InputStream is = null;
         try {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
@@ -6,6 +6,7 @@ import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.Tag;
 import org.bukkit.World;
@@ -20,6 +21,9 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public class AscendSign implements Listener {
+    private static final String MAIN_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Ascend");
+    private static final String ON_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - ON");
+    private static final String OFF_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - OFF");
 
     @EventHandler
     public void onCraftDetect(CraftDetectEvent event){
@@ -32,8 +36,8 @@ public class AscendSign implements Listener {
             BlockState state = block.getState();
             if(block.getState() instanceof Sign){
                 Sign sign = (Sign) block.getState();
-                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")) {
-                    sign.setLine(0, "Ascend: OFF");
+                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT)) {
+                    sign.setLine(0, MAIN_SIGN_TEXT + OFF_SIGN_TEXT);
                     sign.update();
                 }
             }
@@ -51,7 +55,7 @@ public class AscendSign implements Listener {
             return;
         }
         Sign sign = (Sign) event.getClickedBlock().getState();
-        if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: OFF")) {
+        if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + OFF_SIGN_TEXT)) {
             if (CraftManager.getInstance().getCraftByPlayer(event.getPlayer()) == null) {
                 return;
             }
@@ -60,7 +64,7 @@ public class AscendSign implements Listener {
                 return;
             }
             //c.resetSigns(true, false, true);
-            sign.setLine(0, "Ascend: ON");
+            sign.setLine(0, MAIN_SIGN_TEXT + ON_SIGN_TEXT);
             sign.update(true);
 
             c.setCruiseDirection(CruiseDirection.UP);
@@ -73,14 +77,14 @@ public class AscendSign implements Listener {
             }
             return;
         }
-        if (!ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")) {
+        if (!ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT)) {
             return;
         }
         Craft c = CraftManager.getInstance().getCraftByPlayer(event.getPlayer());
         if (c == null || !c.getType().getBoolProperty(CraftType.CAN_CRUISE)) {
             return;
         }
-        sign.setLine(0, "Ascend: OFF");
+        sign.setLine(0, MAIN_SIGN_TEXT + OFF_SIGN_TEXT);
         sign.update(true);
 
         c.setCruising(false);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ContactsSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ContactsSign.java
@@ -5,6 +5,7 @@ import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftDetectEvent;
 import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.Tag;
 import org.bukkit.World;
@@ -14,6 +15,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
 public class ContactsSign implements Listener{
+    private static final String MAIN_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Contacts");
 
     @EventHandler
     public void onCraftDetect(CraftDetectEvent event){
@@ -26,7 +28,7 @@ public class ContactsSign implements Listener{
             BlockState state = block.getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
-                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Contacts:")) {
+                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT)) {
                     sign.setLine(1, "");
                     sign.setLine(2, "");
                     sign.setLine(3, "");
@@ -40,7 +42,7 @@ public class ContactsSign implements Listener{
     public final void onSignTranslateEvent(SignTranslateEvent event){
         String[] lines = event.getLines();
         Craft craft = event.getCraft();
-        if (!ChatColor.stripColor(lines[0]).equalsIgnoreCase("Contacts:")) {
+        if (!ChatColor.stripColor(lines[0]).equalsIgnoreCase(MAIN_SIGN_TEXT)) {
             return;
         }
         int signLine=1;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -24,6 +24,9 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class CruiseSign implements Listener {
+    private static final String MAIN_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Cruise");
+    private static final String ON_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - ON");
+    private static final String OFF_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - OFF");
 
     @EventHandler
     public void onCraftDetect(@NotNull CraftDetectEvent event) {
@@ -37,8 +40,8 @@ public final class CruiseSign implements Listener {
             if (!(state instanceof Sign))
                 continue;
             Sign sign = (Sign) state;
-            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: ON")) {
-                sign.setLine(0, "Cruise: OFF");
+            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT)) {
+                sign.setLine(0, MAIN_SIGN_TEXT + OFF_SIGN_TEXT);
                 sign.update();
             }
         }
@@ -55,14 +58,14 @@ public final class CruiseSign implements Listener {
 
         Sign sign = (Sign) state;
         String line = ChatColor.stripColor(sign.getLine(0));
-        if (line.equalsIgnoreCase("Cruise: OFF")) {
+        if (line.equalsIgnoreCase(MAIN_SIGN_TEXT + OFF_SIGN_TEXT)) {
             Craft c = CraftManager.getInstance().getCraftByPlayer(event.getPlayer());
             if (c == null || !c.getType().getBoolProperty(CraftType.CAN_CRUISE))
                 return;
             if (!(sign.getBlockData() instanceof WallSign))
                 return;
 
-            sign.setLine(0, "Cruise: ON");
+            sign.setLine(0, MAIN_SIGN_TEXT + ON_SIGN_TEXT);
             sign.update(true);
 
             c.setCruiseDirection(CruiseDirection.fromBlockFace(((WallSign) sign.getBlockData()).getFacing()));
@@ -73,12 +76,12 @@ public final class CruiseSign implements Listener {
                 CraftManager.getInstance().addReleaseTask(c);
             }
         }
-        else if (line.equalsIgnoreCase("Cruise: ON")) {
+        else if (line.equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT)) {
             Craft c = CraftManager.getInstance().getCraftByPlayer(event.getPlayer());
             if (c == null || !c.getType().getBoolProperty(CraftType.CAN_CRUISE))
                 return;
 
-            sign.setLine(0, "Cruise: OFF");
+            sign.setLine(0, MAIN_SIGN_TEXT + OFF_SIGN_TEXT);
             sign.update(true);
             c.setCruising(false);
             c.resetSigns(sign);
@@ -91,7 +94,7 @@ public final class CruiseSign implements Listener {
         String line = ChatColor.stripColor(event.getLine(0));
         if (line == null)
             return;
-        if (!line.equalsIgnoreCase("Cruise: OFF") && !line.equalsIgnoreCase("Cruise: ON"))
+        if (!line.equalsIgnoreCase(MAIN_SIGN_TEXT + OFF_SIGN_TEXT) && !line.equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT))
             return;
         if (player.hasPermission("movecraft.cruisesign") || !Settings.RequireCreatePerm)
             return;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
@@ -6,6 +6,7 @@ import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.Tag;
 import org.bukkit.World;
@@ -19,6 +20,9 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class DescendSign implements Listener{
+    private static final String MAIN_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Descend");
+    private static final String ON_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - ON");
+    private static final String OFF_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - OFF");
 
     @EventHandler
     public void onCraftDetect(CraftDetectEvent event){
@@ -31,8 +35,8 @@ public final class DescendSign implements Listener{
             BlockState state = block.getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
-                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")) {
-                    sign.setLine(0, "Descend: OFF");
+                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT)) {
+                    sign.setLine(0, MAIN_SIGN_TEXT + OFF_SIGN_TEXT);
                     sign.update();
                 }
             }
@@ -49,7 +53,7 @@ public final class DescendSign implements Listener{
             return;
         }
         Sign sign = (Sign) state;
-        if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: OFF")) {
+        if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + OFF_SIGN_TEXT)) {
             if (CraftManager.getInstance().getCraftByPlayer(event.getPlayer()) == null) {
                 return;
             }
@@ -58,7 +62,7 @@ public final class DescendSign implements Listener{
                 return;
             }
             //c.resetSigns(true, true, false);
-            sign.setLine(0, "Descend: ON");
+            sign.setLine(0, MAIN_SIGN_TEXT + ON_SIGN_TEXT);
             sign.update(true);
 
             c.setCruiseDirection(CruiseDirection.DOWN);
@@ -71,10 +75,10 @@ public final class DescendSign implements Listener{
             }
             return;
         }
-        if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")) {
+        if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT + ON_SIGN_TEXT)) {
             Craft c = CraftManager.getInstance().getCraftByPlayer(event.getPlayer());
             if (c != null && c.getType().getBoolProperty(CraftType.CAN_CRUISE)) {
-                sign.setLine(0, "Descend: OFF");
+                sign.setLine(0, MAIN_SIGN_TEXT + OFF_SIGN_TEXT);
                 sign.update(true);
                 c.setCruising(false);
                 c.resetSigns(sign);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/HelmSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/HelmSign.java
@@ -18,10 +18,11 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class HelmSign implements Listener {
+    private static final String MAIN_SIGN_TEXT = I18nSupport.getInternationalisedString("Sign - Helm");
 
     @EventHandler
     public void onSignChange(SignChangeEvent event){
-        if (!ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase("[helm]")) {
+        if (!ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase(MAIN_SIGN_TEXT)) {
             return;
         }
         event.setLine(0, "\\  ||  /");

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/MoveSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/MoveSign.java
@@ -14,7 +14,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class MoveSign implements Listener{
-    private static final String HEADER = "Move:";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Move");
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSignClick(@NotNull PlayerInteractEvent event) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/NameSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/NameSign.java
@@ -5,6 +5,7 @@ import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.PilotedCraft;
 import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.util.ChatUtils;
 import org.bukkit.Tag;
 import org.bukkit.World;
@@ -19,7 +20,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public final class NameSign implements Listener {
-    private static final String HEADER = "Name:";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Name");;
     @EventHandler
     public void onCraftDetect(@NotNull CraftDetectEvent event) {
         Craft c = event.getCraft();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/PilotSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/PilotSign.java
@@ -1,12 +1,13 @@
 package net.countercraft.movecraft.sign;
 
+import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.SignChangeEvent;
 
 public final class PilotSign implements Listener {
-    private static final String HEADER = "Pilot:";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Pilot");
     @EventHandler
     public final void onSignChange(SignChangeEvent event){
         if (event.getLine(0).equalsIgnoreCase(HEADER)) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RelativeMoveSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RelativeMoveSign.java
@@ -14,7 +14,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class RelativeMoveSign implements Listener{
-    private static final String HEADER = "RMove:";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Relative move");
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSignClick(@NotNull PlayerInteractEvent event) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ReleaseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ReleaseSign.java
@@ -3,6 +3,7 @@ package net.countercraft.movecraft.sign;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
+import net.countercraft.movecraft.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -14,7 +15,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class ReleaseSign implements Listener{
-    private static final String HEADER = "Release";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Release");
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSignClick(@NotNull PlayerInteractEvent event) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RemoteSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/RemoteSign.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
 import static net.countercraft.movecraft.util.ChatUtils.ERROR_PREFIX;
 
 public final class RemoteSign implements Listener{
-    private static final String HEADER = "Remote Sign";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Remote");
 
     @EventHandler
     public final void onSignChange(SignChangeEvent event) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ScuttleSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/ScuttleSign.java
@@ -24,7 +24,7 @@ import static net.countercraft.movecraft.util.ChatUtils.MOVECRAFT_COMMAND_PREFIX
 
 public class ScuttleSign implements Listener {
 
-    private static final String HEADER = "Scuttle";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Scuttle");
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSignClick(@NotNull PlayerInteractEvent event) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SpeedSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SpeedSign.java
@@ -22,6 +22,8 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 public final class SpeedSign implements Listener{
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Speed");
+
     @EventHandler
     public void onCraftDetect(CraftDetectEvent event){
         World world = event.getCraft().getWorld();
@@ -35,7 +37,7 @@ public final class SpeedSign implements Listener{
                 continue;
 
             Sign sign = (Sign) state;
-            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Speed:")) {
+            if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(HEADER)) {
                 sign.setLine(1, "0 m/s");
                 sign.setLine(2, "0ms");
                 sign.setLine(3, "0T");
@@ -47,7 +49,7 @@ public final class SpeedSign implements Listener{
     @EventHandler
     public void onSignTranslate(SignTranslateEvent event) {
         Craft craft = event.getCraft();
-        if (!ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase("Speed:")) {
+        if (!ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase(HEADER)) {
             return;
         }
         event.setLine(1,String.format("%.2f",craft.getSpeed()) + "m/s");
@@ -69,7 +71,7 @@ public final class SpeedSign implements Listener{
             return;
 
         Sign sign = (Sign) state;
-        if (!ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Speed:"))
+        if (!ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(HEADER))
             return;
 
         Player player = event.getPlayer();

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
@@ -10,6 +10,7 @@ import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.craft.type.RequiredBlockEntry;
 import net.countercraft.movecraft.events.CraftDetectEvent;
 import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.util.Counter;
 import net.countercraft.movecraft.util.Tags;
 import org.bukkit.ChatColor;
@@ -30,6 +31,8 @@ import java.util.Map;
 import java.util.logging.Level;
 
 public final class StatusSign implements Listener{
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Status");
+    private static final String FUEL_RANGE_LINE = I18nSupport.getInternationalisedString("Sign - Status/Fuel range");
 
     @EventHandler
     public void onCraftDetect(CraftDetectEvent event){
@@ -42,7 +45,7 @@ public final class StatusSign implements Listener{
             BlockState state = block.getState();
             if(state instanceof Sign){
                 Sign sign = (Sign) state;
-                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Status:")) {
+                if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase(HEADER)) {
                     sign.setLine(1, "");
                     sign.setLine(2, "");
                     sign.setLine(3, "");
@@ -55,7 +58,7 @@ public final class StatusSign implements Listener{
     @EventHandler
     public final void onSignTranslate(SignTranslateEvent event) {
         Craft craft = event.getCraft();
-        if (!ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase("Status:")) {
+        if (!ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase(HEADER)) {
             return;
         }
         double fuel = craft.getTotalFuel();
@@ -149,7 +152,7 @@ public final class StatusSign implements Listener{
         } else {
             fuelText+=ChatColor.RED;
         }
-        fuelText+="Fuel range:";
+        fuelText+=FUEL_RANGE_LINE;
         fuelText+=fuelRange;
         event.setLine(signLine,fuelText);
     }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SubcraftRotateSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SubcraftRotateSign.java
@@ -34,7 +34,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public final class SubcraftRotateSign implements Listener {
-    private static final String HEADER = "Subcraft Rotate";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Subcraft rotate");
     private final Set<MovecraftLocation> rotating = new HashSet<>();
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/TeleportSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/TeleportSign.java
@@ -17,7 +17,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 public final class TeleportSign implements Listener {
-    private static final String HEADER = "Teleport:";
+    private static final String HEADER = I18nSupport.getInternationalisedString("Sign - Teleport");
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onSignClick(@NotNull PlayerInteractEvent event) {

--- a/modules/Movecraft/src/main/resources/config.yml
+++ b/modules/Movecraft/src/main/resources/config.yml
@@ -28,3 +28,4 @@ ForbiddenRemoteSigns: # These strings will be ignored when searching for signs t
   - "[private]"
 CompatibilityMode: false
 GeneratedDatapack: false # Set to false to re-generate datapack on startup
+UsePropertiesDefaults: false # Substitute property value in English (from local file or then from jar) instead of key for unspecified language fields

--- a/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
+++ b/modules/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
@@ -137,3 +137,28 @@ Error=ERROR
 Direct\ Control\ -\ Entering=Entering Direct Control Mode
 Direct\ Control\ -\ Leaving=Leaving Direct Control Mode
 You\ must\ be\ piloting\ a\ craft=You must be piloting a craft
+
+Cruising\ -\ Main\ action\ bar\ text=Cruising 
+Cruising\ -\ Enabled\ action\ bar\ text=Enabled
+Cruising\ -\ Disabled\ action\ bar\ text=Disabled
+
+Sign\ -\ ON=ON
+Sign\ -\ OFF=OFF
+Sign\ -\ Ascend=Ascend: 
+Sign\ -\ Cruise=Cruise: 
+Sign\ -\ Descend=Descend: 
+
+Sign\ -\ Contacts=Contacts:
+Sign\ -\ Helm=[helm]
+Sign\ -\ Move=Move:
+Sign\ -\ Name=Name:
+Sign\ -\ Pilot=Pilot:
+Sign\ -\ Relative\ move=RMove:
+Sign\ -\ Release=Release
+Sign\ -\ Remote=Remote Sign
+Sign\ -\ Scuttle=Scuttle
+Sign\ -\ Speed=Speed:
+Sign\ -\ Status=Status:
+Sign\ -\ Status/Fuel\ range=Fuel range:
+Sign\ -\ Subcraft\ rotate=Subcraft Rotate:
+Sign\ -\ Teleport=Teleport:


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
1. Using UTF-8 encoding for .properties files (Minecraft uses it by default, and also due to incorrect reading of the file by the plugin, some translations did not work correctly)
2. Added option `UsePropertiesDefaults` in config file that allows substitute property value in English instead of key for unspecified language fields. (If the key is missing in used localisation "movecraftlang_[lang].properties" file it will be searched in "movecraftlang_en.properties" or then in the same 'en' file but in _jar_ resources)
3.  `Cruising action bar message` has been moved to localisation _.properties_ files instead of hardcoded string.
4. All control and information signs have been moved to localisation files. Thus, you can flexibly adjust them to your server.

### Related issues:
- People complained about it (UTF-8) in Discord

### Checklist
- [x] Proper internationalization (There is a problem with the operation of the signs,because by default when the plugin is updated, they will not work due to the fact that the property keys will not be in the previously saved localization file. If you set the `UsePropertiesDefaults` option to `true`, everything will work correctly)
- [x] Tested
