### PR TITLE
Fix IAsyncChunk for 1.19.4

### DIFF
--- a/modules/api/src/main/java/net/countercraft/movecraft/processing/WorldManager.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/processing/WorldManager.java
@@ -65,7 +65,7 @@ public final class WorldManager implements Executor {
             } catch (InterruptedException e) {
                 continue;
             }
-            if(runningTasks.isEmpty()){
+            if(runningTasks.isEmpty() || runningTasks.get(0) == null){
                 Bukkit.getLogger().severe("WorldManager timed out on task query! Dumping " + inProgress.size() + " tasks.");
                 inProgress.forEach(task -> task.cancel(true));
                 worldChanges.clear();

--- a/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/support/v1_19_R3/IAsyncChunk.java
+++ b/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/support/v1_19_R3/IAsyncChunk.java
@@ -7,6 +7,7 @@ import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.support.AsyncChunk;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
@@ -25,9 +26,13 @@ public class IAsyncChunk extends AsyncChunk<CraftChunk> {
             return WorldManager.INSTANCE.executeMain(block::getState);
         }
     });
+    
+    // getHandle needs to be access in the main thread as of 1.19.4
+    private final ChunkAccess handle;
 
     public IAsyncChunk(@NotNull Chunk chunk) {
         super(chunk);
+        handle = this.chunk.getHandle(ChunkStatus.FULL);
     }
 
     @NotNull
@@ -51,6 +56,6 @@ public class IAsyncChunk extends AsyncChunk<CraftChunk> {
     @Override
     @NotNull
     public BlockData getData(@NotNull MovecraftLocation location){
-        return CraftBlockData.fromData(chunk.getHandle(ChunkStatus.FULL).getBlockState(new BlockPos(location.getX(), location.getY(), location.getZ())));
+        return CraftBlockData.fromData(handle.getBlockState(new BlockPos(location.getX(), location.getY(), location.getZ())));
     }
 }


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
- CraftHandle::getHandle now requires to be run on main thread as of 1.19.4, so call it in the constructor of IAsyncChunk
- Fix issue with WorldManager not checking for timeout correctly. When the .poll() function times out from the blocking queue, it will return a null. Old check was only checking if result was empty, but it needs to check if first element is null as well.

### Related issues:
- fixes #576 

### Checklist
- [x] Tested
