### PR TITLE
Update menu access locations when crafts move

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -18,6 +18,7 @@
 package net.countercraft.movecraft.async.rotation;
 
 import net.countercraft.movecraft.CruiseDirection;
+import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.MovecraftRotation;
 import net.countercraft.movecraft.async.AsyncTask;
@@ -187,8 +188,8 @@ public class RotationTask extends AsyncTask {
 
                 if (entity instanceof HumanEntity) {
                     InventoryView inventoryView = ((HumanEntity) entity).getOpenInventory();
-                    if (inventoryView.getType() == InventoryType.WORKBENCH) {
-                        Location l = inventoryView.getTopInventory().getLocation();
+                    if (inventoryView.getType() != InventoryType.CRAFTING) {
+                        Location l = Movecraft.getInstance().getWorldHandler().getAccessLocation(inventoryView);
                         if (l != null) {
                             MovecraftLocation location = new MovecraftLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
                             if (oldHitBox.contains(location)) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -29,6 +29,7 @@ import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftRotateEvent;
 import net.countercraft.movecraft.events.CraftTeleportEntityEvent;
 import net.countercraft.movecraft.localisation.I18nSupport;
+import net.countercraft.movecraft.mapUpdater.update.AccessLocationUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.CraftRotateCommand;
 import net.countercraft.movecraft.mapUpdater.update.EntityUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
@@ -43,7 +44,10 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryView;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -180,6 +184,21 @@ public class RotationTask extends AsyncTask {
                     oldHitBox.getXLength() / 2.0 + 1,
                     oldHitBox.getYLength() / 2.0 + 2,
                     oldHitBox.getZLength() / 2.0 + 1)) {
+
+                if (entity instanceof HumanEntity) {
+                    InventoryView inventoryView = ((HumanEntity) entity).getOpenInventory();
+                    if (inventoryView.getType() == InventoryType.WORKBENCH) {
+                        Location l = inventoryView.getTopInventory().getLocation();
+                        if (l != null) {
+                            MovecraftLocation location = new MovecraftLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
+                            if (oldHitBox.contains(location)) {
+                                location = MathUtils.rotateVec(rotation, location.subtract(originPoint)).add(originPoint);
+                                updates.add(new AccessLocationUpdateCommand(inventoryView, location.toBukkit(w)));
+                            }
+                        }
+                    }
+                }
+
                 if (!craft.getType().getBoolProperty(CraftType.ONLY_MOVE_PLAYERS) || (
                         (entity.getType() == EntityType.PLAYER || entity.getType() == EntityType.PRIMED_TNT)
                                 && !(craft instanceof SinkingCraft)

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -415,8 +415,8 @@ public class TranslationTask extends AsyncTask {
 
                 if (entity instanceof HumanEntity) {
                     InventoryView inventoryView = ((HumanEntity) entity).getOpenInventory();
-                    if (inventoryView.getType() == InventoryType.WORKBENCH) {
-                        Location l = inventoryView.getTopInventory().getLocation();
+                    if (inventoryView.getType() != InventoryType.CRAFTING) {
+                        Location l = Movecraft.getInstance().getWorldHandler().getAccessLocation(inventoryView);
                         if (l != null) {
                             MovecraftLocation location = new MovecraftLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
                             if (oldHitBox.contains(location)) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -18,6 +18,7 @@ import net.countercraft.movecraft.events.CraftTeleportEntityEvent;
 import net.countercraft.movecraft.events.CraftTranslateEvent;
 import net.countercraft.movecraft.events.ItemHarvestEvent;
 import net.countercraft.movecraft.localisation.I18nSupport;
+import net.countercraft.movecraft.mapUpdater.update.AccessLocationUpdateCommand;
 import net.countercraft.movecraft.mapUpdater.update.BlockCreateCommand;
 import net.countercraft.movecraft.mapUpdater.update.CraftTranslateCommand;
 import net.countercraft.movecraft.mapUpdater.update.EntityUpdateCommand;
@@ -43,8 +44,11 @@ import org.bukkit.block.Chest;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -408,6 +412,21 @@ public class TranslationTask extends AsyncTask {
                     oldHitBox.getYLength() / 2.0 + 2,
                     oldHitBox.getZLength() / 2.0 + 1
             )) {
+
+                if (entity instanceof HumanEntity) {
+                    InventoryView inventoryView = ((HumanEntity) entity).getOpenInventory();
+                    if (inventoryView.getType() == InventoryType.WORKBENCH) {
+                        Location l = inventoryView.getTopInventory().getLocation();
+                        if (l != null) {
+                            MovecraftLocation location = new MovecraftLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
+                            if (oldHitBox.contains(location)) {
+                                location = location.translate(dx, dy, dz);
+                                updates.add(new AccessLocationUpdateCommand(inventoryView, location.toBukkit(world)));
+                            }
+                        }
+                    }
+                }
+
                 if ((entity.getType() == EntityType.PLAYER && !(craft instanceof SinkingCraft))) {
                     CraftTeleportEntityEvent e = new CraftTeleportEntityEvent(craft, entity);
                     Bukkit.getServer().getPluginManager().callEvent(e);

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/AccessLocationUpdateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/AccessLocationUpdateCommand.java
@@ -1,0 +1,48 @@
+package net.countercraft.movecraft.mapUpdater.update;
+
+import net.countercraft.movecraft.Movecraft;
+import org.bukkit.Location;
+import org.bukkit.inventory.InventoryView;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class AccessLocationUpdateCommand extends UpdateCommand {
+
+    private final @NotNull InventoryView inventoryView;
+    private final @NotNull Location newAccessLocation;
+
+    public AccessLocationUpdateCommand(@NotNull InventoryView inventoryView, @NotNull Location newAccessLocation) {
+        this.inventoryView = inventoryView;
+        this.newAccessLocation = newAccessLocation;
+    }
+
+    public @NotNull InventoryView getInventoryView() {
+        return inventoryView;
+    }
+
+    public @NotNull Location getNewAccessLocation() {
+        return newAccessLocation;
+    }
+
+    @Override
+    public void doUpdate() {
+        Movecraft.getInstance().getWorldHandler().setAccessLocation(inventoryView, newAccessLocation);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof AccessLocationUpdateCommand)) {
+            return false;
+        }
+        AccessLocationUpdateCommand other = (AccessLocationUpdateCommand) obj;
+        return other.inventoryView.equals(this.inventoryView) &&
+                other.newAccessLocation.equals(this.newAccessLocation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inventoryView, newAccessLocation);
+    }
+
+}

--- a/modules/api/src/main/java/net/countercraft/movecraft/WorldHandler.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/WorldHandler.java
@@ -8,6 +8,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class WorldHandler {
     public abstract void rotateCraft(@NotNull Craft craft, @NotNull MovecraftLocation originLocation, @NotNull MovecraftRotation rotation);
@@ -15,5 +16,6 @@ public abstract class WorldHandler {
     public abstract void setBlockFast(@NotNull Location location, @NotNull BlockData data);
     public abstract void setBlockFast(@NotNull Location location, @NotNull MovecraftRotation rotation, @NotNull BlockData data);
     public abstract void disableShadow(@NotNull Material type);
+    public abstract @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView);
     public abstract void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location);
 }

--- a/modules/api/src/main/java/net/countercraft/movecraft/WorldHandler.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/WorldHandler.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class WorldHandler {
@@ -14,4 +15,5 @@ public abstract class WorldHandler {
     public abstract void setBlockFast(@NotNull Location location, @NotNull BlockData data);
     public abstract void setBlockFast(@NotNull Location location, @NotNull MovecraftRotation rotation, @NotNull BlockData data);
     public abstract void disableShadow(@NotNull Material type);
+    public abstract void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location);
 }

--- a/modules/api/src/main/java/net/countercraft/movecraft/util/UnsafeUtils.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/util/UnsafeUtils.java
@@ -42,7 +42,7 @@ public class UnsafeUtils {
     public static void trySetFieldOfType(@NotNull Class<?> type, @NotNull Object holder, @NotNull Object value) {
         Field field = getFieldOfType(type, holder.getClass());
         if (field != null) {
-            UnsafeUtils.setField(field, holder, value);
+            setField(field, holder, value);
         }
     }
 }

--- a/modules/api/src/main/java/net/countercraft/movecraft/util/UnsafeUtils.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/util/UnsafeUtils.java
@@ -1,5 +1,6 @@
 package net.countercraft.movecraft.util;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import sun.misc.Unsafe;
 
@@ -25,5 +26,23 @@ public class UnsafeUtils {
             return;
         }
         unsafe.putObject(holder, unsafe.objectFieldOffset(field), value);
+    }
+
+    public static @Nullable Field getFieldOfType(@NotNull Class<?> type, @Nullable Class<?> clazz) {
+        if (clazz == null)
+            return null;
+        for (Field field : clazz.getDeclaredFields()) {
+            if (field.getType() == type) {
+                return field;
+            }
+        }
+        return getFieldOfType(type, clazz.getSuperclass());
+    }
+
+    public static void trySetFieldOfType(@NotNull Class<?> type, @NotNull Object holder, @NotNull Object value) {
+        Field field = getFieldOfType(type, holder.getClass());
+        if (field != null) {
+            UnsafeUtils.setField(field, holder, value);
+        }
     }
 }

--- a/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
+++ b/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
@@ -15,7 +15,6 @@ import net.minecraft.server.v1_14_R1.Chunk;
 import net.minecraft.server.v1_14_R1.ChunkSection;
 import net.minecraft.server.v1_14_R1.Container;
 import net.minecraft.server.v1_14_R1.ContainerAccess;
-import net.minecraft.server.v1_14_R1.ContainerWorkbench;
 import net.minecraft.server.v1_14_R1.EnumBlockRotation;
 import net.minecraft.server.v1_14_R1.IBlockData;
 import net.minecraft.server.v1_14_R1.NextTickListEntry;

--- a/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
+++ b/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
@@ -25,6 +25,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_14_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_14_R1.util.CraftMagicNumbers;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -276,6 +277,11 @@ public class IWorldHandler extends WorldHandler {
     @Override
     public void disableShadow(@NotNull Material type) {
         // Disabled
+    }
+
+    @Override
+    public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
+        // Not implemented
     }
 
     private static MovecraftLocation bukkit2MovecraftLoc(Location l) {

--- a/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
+++ b/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
@@ -286,6 +286,11 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Override
+    public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
+        return null; // Not implemented
+    }
+
+    @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
         if (location.getWorld() == null)
             return;

--- a/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
+++ b/modules/v1_14_R1/src/main/java/net/countercraft/movecraft/compat/v1_14_R1/IWorldHandler.java
@@ -287,7 +287,17 @@ public class IWorldHandler extends WorldHandler {
 
     @Override
     public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
-        return null; // Not implemented
+        Container menu = ((CraftInventoryView) inventoryView).getHandle();
+        Field field = UnsafeUtils.getFieldOfType(ContainerAccess.class, menu.getClass());
+        if (field != null) {
+            try {
+                field.setAccessible(true);
+                return ((ContainerAccess) field.get(menu)).getLocation();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
     }
 
     @Override
@@ -299,14 +309,7 @@ public class IWorldHandler extends WorldHandler {
         ContainerAccess access = ContainerAccess.at(level, position);
 
         Container menu = ((CraftInventoryView) inventoryView).getHandle();
-        try {
-            if (menu instanceof ContainerWorkbench) {
-                Field accessField = ContainerWorkbench.class.getDeclaredField("containerAccess");
-                UnsafeUtils.setField(accessField, menu, access);
-            }
-        } catch (NoSuchFieldException e) {
-            e.printStackTrace();
-        }
+        UnsafeUtils.trySetFieldOfType(ContainerAccess.class, menu, access);
     }
 
     private static MovecraftLocation bukkit2MovecraftLoc(Location l) {

--- a/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
+++ b/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
@@ -288,6 +288,11 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Override
+    public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
+        return null; // Not implemented
+    }
+
+    @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
         // Not implemented
     }

--- a/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
+++ b/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
@@ -6,18 +6,18 @@ import net.countercraft.movecraft.WorldHandler;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.util.CollectionUtils;
 import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.util.UnsafeUtils;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.minecraft.server.v1_16_R3.Block;
 import net.minecraft.server.v1_16_R3.BlockPosition;
 import net.minecraft.server.v1_16_R3.Blocks;
 import net.minecraft.server.v1_16_R3.Chunk;
 import net.minecraft.server.v1_16_R3.ChunkSection;
-import net.minecraft.server.v1_16_R3.EntityPlayer;
+import net.minecraft.server.v1_16_R3.Container;
+import net.minecraft.server.v1_16_R3.ContainerAccess;
 import net.minecraft.server.v1_16_R3.EnumBlockRotation;
 import net.minecraft.server.v1_16_R3.IBlockData;
 import net.minecraft.server.v1_16_R3.NextTickListEntry;
-import net.minecraft.server.v1_16_R3.PacketPlayOutPosition;
-import net.minecraft.server.v1_16_R3.PlayerConnection;
 import net.minecraft.server.v1_16_R3.StructureBoundingBox;
 import net.minecraft.server.v1_16_R3.TileEntity;
 import net.minecraft.server.v1_16_R3.World;
@@ -27,23 +27,18 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
-import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryView;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @SuppressWarnings("unused")
 public class IWorldHandler extends WorldHandler {
@@ -287,14 +282,30 @@ public class IWorldHandler extends WorldHandler {
         // Disabled
     }
 
-    @Override
     public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
-        return null; // Not implemented
+        Container menu = ((CraftInventoryView) inventoryView).getHandle();
+        Field field = UnsafeUtils.getFieldOfType(ContainerAccess.class, menu.getClass());
+        if (field != null) {
+            try {
+                field.setAccessible(true);
+                return ((ContainerAccess) field.get(menu)).getLocation();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
     }
 
     @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
-        // Not implemented
+        if (location.getWorld() == null)
+            return;
+        WorldServer level = ((CraftWorld) location.getWorld()).getHandle();
+        BlockPosition position = new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        ContainerAccess access = ContainerAccess.at(level, position);
+
+        Container menu = ((CraftInventoryView) inventoryView).getHandle();
+        UnsafeUtils.trySetFieldOfType(ContainerAccess.class, menu, access);
     }
 
     private static MovecraftLocation bukkit2MovecraftLoc(Location l) {

--- a/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
+++ b/modules/v1_16_R3/src/main/java/net/countercraft/movecraft/compat/v1_16_R3/IWorldHandler.java
@@ -30,6 +30,7 @@ import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -284,6 +285,11 @@ public class IWorldHandler extends WorldHandler {
     @Override
     public void disableShadow(@NotNull Material type) {
         // Disabled
+    }
+
+    @Override
+    public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
+        // Not implemented
     }
 
     private static MovecraftLocation bukkit2MovecraftLoc(Location l) {

--- a/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
+++ b/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
@@ -9,6 +9,8 @@ import net.countercraft.movecraft.util.MathUtils;
 import net.countercraft.movecraft.util.UnsafeUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.TickNextTickData;
 import net.minecraft.world.level.block.Block;
@@ -23,11 +25,13 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftInventoryView;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -250,12 +254,29 @@ public class IWorldHandler extends WorldHandler {
 
     @Override
     public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
-        return null; // Not implemented
+        AbstractContainerMenu menu = ((CraftInventoryView) inventoryView).getHandle();
+        Field field = UnsafeUtils.getFieldOfType(ContainerLevelAccess.class, menu.getClass());
+        if (field != null) {
+            try {
+                field.setAccessible(true);
+                return ((ContainerLevelAccess) field.get(menu)).getLocation();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
     }
 
     @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
-        // Not implemented
+        if (location.getWorld() == null)
+            return;
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle();
+        BlockPos position = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        ContainerLevelAccess access = ContainerLevelAccess.create(level, position);
+
+        AbstractContainerMenu menu = ((CraftInventoryView) inventoryView).getHandle();
+        UnsafeUtils.trySetFieldOfType(ContainerLevelAccess.class, menu, access);
     }
 
     private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {

--- a/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
+++ b/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
@@ -24,6 +24,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -245,6 +246,11 @@ public class IWorldHandler extends WorldHandler {
     @Override
     public void disableShadow(@NotNull Material type) {
         // Disabled
+    }
+
+    @Override
+    public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
+        // Not implemented
     }
 
     private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {

--- a/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
+++ b/modules/v1_17_R1/src/main/java/net/countercraft/movecraft/compat/v1_17_R1/IWorldHandler.java
@@ -249,6 +249,11 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Override
+    public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
+        return null; // Not implemented
+    }
+
+    @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
         // Not implemented
     }

--- a/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
+++ b/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
@@ -24,6 +24,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -245,6 +246,11 @@ public class IWorldHandler extends WorldHandler {
     @Override
     public void disableShadow(@NotNull Material type) {
         // Disabled
+    }
+
+    @Override
+    public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
+        // Not implemented
     }
 
     private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {

--- a/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
+++ b/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
@@ -9,6 +9,8 @@ import net.countercraft.movecraft.util.MathUtils;
 import net.countercraft.movecraft.util.UnsafeUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -23,11 +25,13 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryView;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -250,12 +254,29 @@ public class IWorldHandler extends WorldHandler {
 
     @Override
     public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
-        return null; // Not implemented
+        AbstractContainerMenu menu = ((CraftInventoryView) inventoryView).getHandle();
+        Field field = UnsafeUtils.getFieldOfType(ContainerLevelAccess.class, menu.getClass());
+        if (field != null) {
+            try {
+                field.setAccessible(true);
+                return ((ContainerLevelAccess) field.get(menu)).getLocation();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
     }
 
     @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
-        // Not implemented
+        if (location.getWorld() == null)
+            return;
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle();
+        BlockPos position = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        ContainerLevelAccess access = ContainerLevelAccess.create(level, position);
+
+        AbstractContainerMenu menu = ((CraftInventoryView) inventoryView).getHandle();
+        UnsafeUtils.trySetFieldOfType(ContainerLevelAccess.class, menu, access);
     }
 
     private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {

--- a/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
+++ b/modules/v1_18_R2/src/main/java/net/countercraft/movecraft/compat/v1_18_R2/IWorldHandler.java
@@ -249,6 +249,11 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Override
+    public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
+        return null; // Not implemented
+    }
+
+    @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
         // Not implemented
     }

--- a/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/compat/v1_19_R3/IWorldHandler.java
+++ b/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/compat/v1_19_R3/IWorldHandler.java
@@ -24,6 +24,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R3.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
+import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -245,6 +246,11 @@ public class IWorldHandler extends WorldHandler {
     @Override
     public void disableShadow(@NotNull Material type) {
         // Disabled
+    }
+
+    @Override
+    public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
+        // Not implemented
     }
 
     private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {

--- a/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/compat/v1_19_R3/IWorldHandler.java
+++ b/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/compat/v1_19_R3/IWorldHandler.java
@@ -249,6 +249,11 @@ public class IWorldHandler extends WorldHandler {
     }
 
     @Override
+    public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
+        return null; // Not implemented
+    }
+
+    @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
         // Not implemented
     }

--- a/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/compat/v1_19_R3/IWorldHandler.java
+++ b/modules/v1_19_R3/src/main/java/net/countercraft/movecraft/compat/v1_19_R3/IWorldHandler.java
@@ -9,6 +9,8 @@ import net.countercraft.movecraft.util.MathUtils;
 import net.countercraft.movecraft.util.UnsafeUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -23,11 +25,13 @@ import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R3.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftInventoryView;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -250,12 +254,29 @@ public class IWorldHandler extends WorldHandler {
 
     @Override
     public @Nullable Location getAccessLocation(@NotNull InventoryView inventoryView) {
-        return null; // Not implemented
+        AbstractContainerMenu menu = ((CraftInventoryView) inventoryView).getHandle();
+        Field field = UnsafeUtils.getFieldOfType(ContainerLevelAccess.class, menu.getClass());
+        if (field != null) {
+            try {
+                field.setAccessible(true);
+                return ((ContainerLevelAccess) field.get(menu)).getLocation();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
     }
 
     @Override
     public void setAccessLocation(@NotNull InventoryView inventoryView, @NotNull Location location) {
-        // Not implemented
+        if (location.getWorld() == null)
+            return;
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle();
+        BlockPos position = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        ContainerLevelAccess access = ContainerLevelAccess.create(level, position);
+
+        AbstractContainerMenu menu = ((CraftInventoryView) inventoryView).getHandle();
+        UnsafeUtils.trySetFieldOfType(ContainerLevelAccess.class, menu, access);
     }
 
     private void moveBlockEntity(@NotNull Level nativeWorld, @NotNull BlockPos newPosition, @NotNull BlockEntity tile) {


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
(Re-opened #563)
At the same time as players are teleported by moving crafts, my code checks if their currently opened inventory is attached to a block on the craft. If it is, the `ContainerLevelAccess` of the menu is updated based on the motion of the craft. This means that when the server checks if the block is still there on the next tick, it will check the new location of the block and keep the inventory open for the player, which enables usage of crafting tables, anvils, looms, enchantment tables, ect. on moving crafts.

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
- Fixes #562

### Checklist
- [x] Proper internationalization
- [x] Tested (on all supported versions)
