### PR TITLE
Dismantler issues

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -49,7 +49,14 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Logger;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -467,6 +467,8 @@ public class TranslationTask extends AsyncTask {
         return false;
     }
 
+    private static final ItemStack YIELD_TOOL = new ItemStack(Material.DIAMOND_PICKAXE);
+
     private void captureYield(List<MovecraftLocation> harvestedBlocks) {
         if (harvestedBlocks.isEmpty()) {
             return;
@@ -481,7 +483,7 @@ public class TranslationTask extends AsyncTask {
 
         for (MovecraftLocation harvestedBlock : harvestedBlocks) {
             Block block = craft.getWorld().getBlockAt(harvestedBlock.getX(), harvestedBlock.getY(), harvestedBlock.getZ());
-            List<ItemStack> drops = new ArrayList<>(block.getDrops());
+            List<ItemStack> drops = new ArrayList<>(block.getDrops(YIELD_TOOL));
             //generate seed drops
             if (block.getType() == Material.WHEAT) {
                 Random rand = new Random();


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
This PR addresses a change in the Spigot API behavior of `Block#getDrops()`.  Previously, the method would return the drops for optimal tool.  However, the method now returns the drops for the specified tool, or a hand if none is provided.  The new algorithm cycles through a number of predetermined tools which should get all drops from blocks.

### Checklist
- [x] Tested
