### PR TITLE
Craft DataTags and trackedlocations

### DIFF
--- a/modules/MakeItBuild.md
+++ b/modules/MakeItBuild.md
@@ -1,0 +1,1 @@
+Make it Build!

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -83,10 +83,6 @@ public abstract class BaseCraft implements Craft {
     private String name = "";
     @NotNull
     private MovecraftLocation lastTranslation = new MovecraftLocation(0, 0, 0);
-    @NotNull
-    private Map<Object, Collection<Object>> trackedLocations = new HashMap<>();
-    @NotNull
-    private Map<String, Object> craftTags = new HashMap<>();
 
     public BaseCraft(@NotNull CraftType type, @NotNull World world) {
         this.type = type;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -15,6 +15,10 @@ import net.countercraft.movecraft.processing.MovecraftWorld;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.util.Counter;
 import net.countercraft.movecraft.util.Tags;
+
+import net.countercraft.movecraft.util.CollectionUtils;
+import net.countercraft.movecraft.util.MathUtils;
+
 import net.countercraft.movecraft.util.TimingData;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.countercraft.movecraft.util.hitboxes.MutableHitBox;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -30,6 +30,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.EnumSet;

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -85,7 +85,7 @@ public class CraftRotateCommand extends UpdateCommand {
                     }
                 }
                 if (!clone.isEmpty() || clone != null) {
-                    ((BaseCraft)craft).setTrackedLocs(clone,key);
+                    (craft).setTrackedLocs(clone,key);
                 }
             }
         }

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -69,6 +69,26 @@ public class CraftRotateCommand extends UpdateCommand {
             CraftManager.getInstance().release(craft, CraftReleaseEvent.Reason.EMPTY, false);
             return;
         }
+        if (craft.trackedLocations != null) {
+            for (Object key : craft.trackedLocations.keySet()) {
+                ArrayList<Object> mlocs = new ArrayList<>(craft.getTrackedLocs(key));
+                for (Object tracked : mlocs) {
+                    if (tracked != null) {
+                        if (tracked instanceof MovecraftLocation) {
+                            MovecraftLocation newTracked = MathUtils.rotateVec(rotation,((MovecraftLocation)tracked).subtract(originLocation)).add(originLocation);
+                            clone.add(newTracked);
+                        }
+                        if (tracked instanceof HitBox) {
+                            HitBox newBox = (SetHitBox)(craft).rotateBox(((HitBox)tracked), originLocation, rotation);
+                            clone.add(newBox);
+                        }
+                    }
+                }
+                if (!clone.isEmpty() || clone != null) {
+                    ((BaseCraft)craft).setTrackedLocs(clone,key);
+                }
+            }
+        }
         long time = System.nanoTime();
         final Set<Material> passthroughBlocks = new HashSet<>(craft.getType().getMaterialSetProperty(CraftType.PASSTHROUGH_BLOCKS));
         if (craft instanceof SinkingCraft) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -70,6 +70,7 @@ public class CraftRotateCommand extends UpdateCommand {
             return;
         }
         if (craft.trackedLocations != null) {
+            ArrayList<Object> clone = new ArrayList<>();
             for (Object key : craft.trackedLocations.keySet()) {
                 ArrayList<Object> mlocs = new ArrayList<>(craft.getTrackedLocs(key));
                 for (Object tracked : mlocs) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -75,6 +75,7 @@ public class CraftTranslateCommand extends UpdateCommand {
             CraftManager.getInstance().release(craft, CraftReleaseEvent.Reason.EMPTY, false);
             return;
         }
+        
         if (craft.trackedLocations != null) {
             for (Object key : craft.trackedLocations.keySet()) {
                 ArrayList<Object> mlocs = new ArrayList<>(craft.trackedLocations.get(key));
@@ -94,7 +95,8 @@ public class CraftTranslateCommand extends UpdateCommand {
                 if (!clone.isEmpty() || clone != null) {
                     ((BaseCraft)craft).setTrackedLocs(clone,key);
                 }
-            
+            }
+        }
         long time = System.nanoTime();
         World oldWorld = craft.getWorld();
         final Set<Material> passthroughBlocks = new HashSet<>(

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -75,6 +75,26 @@ public class CraftTranslateCommand extends UpdateCommand {
             CraftManager.getInstance().release(craft, CraftReleaseEvent.Reason.EMPTY, false);
             return;
         }
+        if (craft.trackedLocations != null) {
+            for (Object key : craft.trackedLocations.keySet()) {
+                ArrayList<Object> mlocs = new ArrayList<>(craft.trackedLocations.get(key));
+                Set<Object> clone = new HashSet<>();
+                for (Object tracked : mlocs) {
+                    if (tracked != null) {
+                        if (tracked instanceof MovecraftLocation) {
+                            MovecraftLocation newTracked = ((MovecraftLocation)tracked).translate(displacement.getX(),displacement.getY(),displacement.getZ());
+                            clone.add(newTracked);
+                        }
+                        if (tracked instanceof HitBox) {
+                            HitBox newBox = (SetHitBox)(craft.translateBox(((SetHitBox)tracked), displacement));
+                            clone.add(newBox);
+                        }
+                    }
+                }
+                if (!clone.isEmpty() || clone != null) {
+                    ((BaseCraft)craft).setTrackedLocs(clone,key);
+                }
+            
         long time = System.nanoTime();
         World oldWorld = craft.getWorld();
         final Set<Material> passthroughBlocks = new HashSet<>(

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftTranslateCommand.java
@@ -93,7 +93,7 @@ public class CraftTranslateCommand extends UpdateCommand {
                     }
                 }
                 if (!clone.isEmpty() || clone != null) {
-                    ((BaseCraft)craft).setTrackedLocs(clone,key);
+                    (craft).setTrackedLocs(clone,key);
                 }
             }
         }

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -67,6 +68,9 @@ public interface Craft {
     CraftType getType();
 
 
+    Map<Object, Collection<Object>> trackedLocations = new HashMap<>();
+
+    Map<String, Object> craftTags = new HashMap<>();
 
     /**
      * Attaches a Key-Value Pair to a Craft Object. 

--- a/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/modules/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -35,6 +35,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,7 +46,6 @@ public interface Craft {
 
     @Deprecated
     void setProcessing(boolean processing);
-
     /**
      * Gets a HitBox representing the current locations that this craft controls
      *
@@ -58,7 +58,6 @@ public interface Craft {
      * Sets the HitBox representing the current locations that this craft controls
      */
     void setHitBox(@NotNull HitBox hitBox);
-
     /**
      * Gets the CraftType used to determine the Craft's behaviours
      *
@@ -67,6 +66,91 @@ public interface Craft {
     @NotNull
     CraftType getType();
 
+
+
+    /**
+     * Attaches a Key-Value Pair to a Craft Object. 
+     */
+    void setDataTag(@NotNull String key, @Nullable Object data);
+
+    /**
+     * Gets the Value of and then Removes the Key, if Present (Otherwise Returns Null).
+     */
+    @Nullable
+    Object removeDataTag(String key);
+
+    /**
+     * Gets a Tag Value from a Keys.
+     */
+    @Nullable
+    Object getDataTag(String key);
+
+    /**
+     * Gets all Tag Values from all Keys.
+     */
+    @NotNull
+    Collection<Object> getAllTagValues();
+
+    /**
+     * Checks if the Craft has a certain Key out of all Keys
+     */
+    @NotNull
+    boolean hasDataKey(String key);
+
+    /**
+     * Checks if the Craft has a certain Value from all Keys
+     */
+    @NotNull
+    boolean hasDataValue(Object value);
+
+    /**
+     * Translates the given HitBox by a MovecraftLocation (Which is Treated as a Vector)
+     */
+    @NotNull
+    HitBox translateBox(HitBox box, MovecraftLocation vec);
+
+    /**
+     * Rotates the given HitBox around an Axis by a MovecraftRotation
+     */
+    @NotNull
+    HitBox rotateBox(HitBox box, MovecraftLocation axis, MovecraftRotation rotation);
+
+    /**
+     * Checks if an Object (MovecraftLocation / HitBox) is currently being Tracked.
+     */
+    @NotNull
+    boolean isTracking(@NotNull Object tracked);
+
+    /**
+     * Replaces/Updates a Key of Tracked MovecraftLocation or HitBox
+     */
+    void setTrackedLocs(@NotNull Collection<Object> tracked, @NotNull Object key);
+    /**
+     * Adds a Tracked MovecraftLocation or HitBox to a Key
+     */
+    void addTrackedLoc(@NotNull Object tracked, @NotNull Object key);
+    /**
+     * Removes a Tracked MovecraftLocation or HitBox from a Key
+     */
+    void removeTrackedLoc(@NotNull Object tracked, @NotNull Object key);
+    /**
+     * Gets all Tracked MovecraftLocations (Including from Tracked HitBoxes) from all Keys
+     */
+    Set<Object> getAllTrackedLocation();
+
+    /**
+     * Gets all Tracked MovecraftLocations (Including from Tracked HitBoxes) or HitBox from a particular key
+     */
+    @Nullable
+    Set<MovecraftLocation> getTrackedLocs(@NotNull Object key);
+
+    /**
+     * Gets a HitBox representing the current locations that this craft controls
+     *
+     * @return the crafts current HitBox
+     */
+
+    
     @Deprecated(forRemoval = true) @NotNull
     default World getW(){
         return this.getWorld();


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes



Craft DataTags:
Useful for storing any type of Data in Key-Value format, "aboard" a Craft Object.
As long as the Craft Object isn't erased/lost-track-of, the DataTags will remain.

Example Use-Case:
Storing a List of Players who can Activate Certain Types of Blocks on a craft.
Keeping track of the Number of Damaging Hits Recieved and 

TrackedLocations:
A MovecraftLocation and/or HitBox-Object that will move "with" the Craft it is bound to, when the Craft Translates or Rotates

Example Use-Case:
A Better "Movecraft-Cannons" Addon-Plugin.
Where the Cannon's Locations are automatically Updated/Moved with the Craft upon any successful Movement/Rotation.



### Checklist
- [x] Proper internationalization (N/A)
- [ ] Tested (I have been using my Private Version of this for like a year or two now.)
