### PR TITLE
[Feature / Cleanup] Sign rework

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -222,6 +222,7 @@ public class Movecraft extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ScuttleSign(), this);
         getServer().getPluginManager().registerEvents(new CraftPilotListener(), this);
         getServer().getPluginManager().registerEvents(new CraftReleaseListener(), this);
+        getServer().getPluginManager().registerEvents(new SignListener(), this);
 
         var contactsManager = new ContactsManager();
         contactsManager.runTaskTimerAsynchronously(this, 0, 20);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/SignListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/SignListener.java
@@ -1,0 +1,2 @@
+package net.countercraft.movecraft.listener;public class SignListener {
+}

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/SignListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/SignListener.java
@@ -1,2 +1,82 @@
-package net.countercraft.movecraft.listener;public class SignListener {
+package net.countercraft.movecraft.listener;
+
+import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.sign.AbstractCraftSign;
+import net.countercraft.movecraft.sign.AbstractMovecraftSign;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class SignListener implements Listener {
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onCraftDetect(CraftDetectEvent event) {
+        final World world = event.getCraft().getWorld();;
+        event.getCraft().getHitBox().forEach(
+                (mloc) -> {
+                    Block block = mloc.toBukkit(world).getBlock();
+                    BlockState state = block.getState();
+                    if (state instanceof Sign sign) {
+                        String ident = sign.getLines()[0];
+                        AbstractCraftSign.tryGetCraftSign(ident).ifPresent(acs -> {
+                            acs.onCraftDetect(event);
+                        });
+                    }
+                }
+        );
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onSignTranslate(SignTranslateEvent event) {
+        String ident = event.getLine(0);
+        AbstractCraftSign.tryGetCraftSign(ident).ifPresent(acs -> {
+            acs.onSignMovedByCraft(event);
+        });
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onSignChange(SignChangeEvent event) {
+        Block block = event.getBlock();
+        if (block == null) {
+            return;
+        }
+        BlockState state = block.getState();
+        if (state instanceof Sign sign) {
+            final String signHeader = ChatColor.stripColor(event.getLines()[0]);
+            AbstractMovecraftSign.tryGet(signHeader).ifPresent(ams -> {
+
+                boolean success = ams.processSignChange(event);
+                if (ams.shouldCancelEvent(success, null, event.getPlayer().isSneaking())) {
+                    event.setCancelled(true);
+                }
+            });
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onSignClick(PlayerInteractEvent event) {
+        Block block = event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
+        BlockState state = block.getState();
+        if (state instanceof Sign sign) {
+            final String signHeader = ChatColor.stripColor(sign.getLines()[0]);
+            AbstractMovecraftSign.tryGet(signHeader).ifPresent(ams -> {
+                boolean success = ams.processSignClick(event.getAction(), sign, event.getPlayer());
+                if (ams.shouldCancelEvent(success, event.getAction(), event.getPlayer().isSneaking())) {
+                    event.setCancelled(true);
+                }
+            });
+        }
+    }
+
 }

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftSign.java
@@ -1,2 +1,96 @@
-package net.countercraft.movecraft.sign;public class AbstractCraftSign {
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.PilotedCraft;
+import net.countercraft.movecraft.craft.PlayerCraft;
+import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.util.MathUtils;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.ClickType;
+
+import java.util.Optional;
+
+public abstract class AbstractCraftSign extends AbstractMovecraftSign {
+
+    public static Optional<AbstractCraftSign> tryGetCraftSign(final String ident) {
+        Optional<AbstractMovecraftSign> tmp = AbstractCraftSign.tryGet(ident);
+        if (tmp.isPresent() && tmp.get() instanceof AbstractCraftSign acs) {
+            return Optional.of(acs);
+        }
+        return Optional.empty();
+    }
+
+    private final boolean ignoreCraftIsBusy;
+
+    public AbstractCraftSign(boolean ignoreCraftIsBusy) {
+        this(null, ignoreCraftIsBusy);
+    }
+
+    public AbstractCraftSign(final String permission, boolean ignoreCraftIsBusy) {
+        super(permission);
+        this.ignoreCraftIsBusy = ignoreCraftIsBusy;
+    }
+
+    // Return true to cancel the event
+    @Override
+    public boolean processSignClick(Action clickType, Sign sign, Player player) {
+        if (!this.isSignValid(clickType, sign, player)) {
+            return false;
+        }
+        if (!this.canPlayerUseSign(clickType, sign, player)) {
+            return false;
+        }
+        Optional<Craft> craft = this.getCraft(sign);
+        if (craft.isEmpty()) {
+            this.onCraftNotFound(player, sign);
+            return false;
+        }
+
+        if (craft.get() instanceof PlayerCraft pc) {
+            if (!pc.isNotProcessing() && !this.ignoreCraftIsBusy) {
+                this.onParentCraftBusy(player, craft.get());
+                return false;
+            }
+        }
+
+        return internalProcessSign(clickType, sign, player, craft);
+    }
+
+    protected abstract void onParentCraftBusy(Player player, Craft craft);
+
+    protected boolean canPlayerUseSignOn(Player player, Craft craft) {
+        if (craft instanceof PilotedCraft pc) {
+            return pc.getPilot() == player;
+        }
+        return true;
+    }
+
+    protected abstract void onCraftNotFound(Player player, Sign sign);
+
+    protected boolean canPlayerUseSign(ClickType clickType, Sign sign, Player player) {
+        if (this.optPermission.isPresent()) {
+            return player.hasPermission(this.optPermission.get());
+        }
+        return true;
+    }
+
+    protected abstract boolean internalProcessSign(ClickType clickType, Sign sign, Player player, Optional<Craft> craft);
+
+    protected Optional<Craft> getCraft(Sign sign) {
+        return Optional.ofNullable(MathUtils.getCraftByPersistentBlockData(sign.getLocation()));
+    }
+
+    public void onCraftDetect(CraftDetectEvent event) {
+        // Do nothing by default
+    }
+
+    public void onSignMovedByCraft(SignTranslateEvent event) {
+        // Do nothing by default
+    }
+
+    protected abstract boolean isSignValid(ClickType clickType, Sign sign, Player player);
+
 }

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftSign.java
@@ -1,0 +1,2 @@
+package net.countercraft.movecraft.sign;public class AbstractCraftSign {
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractMovecraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractMovecraftSign.java
@@ -1,2 +1,83 @@
-package net.countercraft.movecraft.sign;public class AbstractMovecraftSign {
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.util.MathUtils;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.SignChangeEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class AbstractMovecraftSign {
+
+    private static final Map<String, AbstractMovecraftSign> SIGNS = Collections.synchronizedMap(new HashMap<>());
+
+    public static boolean hasBeenRegistered(final String ident) {
+        return SIGNS.containsKey(ident);
+    }
+
+    public static Optional<AbstractMovecraftSign> tryGet(final String ident) {
+        String identToUse = ident.toUpperCase();
+        if (identToUse.indexOf(":") >= 0) {
+            identToUse = identToUse.split(":")[0];
+        }
+        return Optional.ofNullable(SIGNS.getOrDefault(identToUse, null));
+    }
+
+    public static void forceRegister(final String ident, final @Nonnull AbstractMovecraftSign instance) {
+        register(ident, instance, true);
+    }
+
+    public static void register(final String ident, final @Nonnull AbstractMovecraftSign instance, boolean allowOverride) {
+        if (allowOverride) {
+            SIGNS.put(ident.toUpperCase(), instance);
+        } else {
+            SIGNS.putIfAbsent(ident.toUpperCase(), instance);
+        }
+    }
+
+    protected final Optional<String> optPermission;
+
+    public AbstractMovecraftSign() {
+        this(null);
+    }
+
+    public AbstractMovecraftSign(String permissionNode) {
+        this.optPermission = Optional.ofNullable(permissionNode);
+    }
+
+    // Return true to cancel the event
+    public boolean processSignClick(Action clickType, Sign sign, Player player) {
+        if (!this.isSignValid(clickType, sign, player)) {
+            return false;
+        }
+        if (!this.canPlayerUseSign(clickType, sign, player)) {
+            return false;
+        }
+
+        return internalProcessSign(clickType, sign, player, getCraft(sign));
+    }
+
+    protected boolean canPlayerUseSign(Action clickType, Sign sign, Player player) {
+        if (this.optPermission.isPresent()) {
+            return player.hasPermission(this.optPermission.get());
+        }
+        return true;
+    }
+
+    protected Optional<Craft> getCraft(Sign sign) {
+        return Optional.ofNullable(MathUtils.getCraftByPersistentBlockData(sign.getLocation()));
+    }
+
+    public abstract boolean shouldCancelEvent(boolean processingSuccessful, @Nullable Action type, boolean sneaking);
+    protected abstract boolean isSignValid(Action clickType, Sign sign, Player player);
+    protected abstract boolean internalProcessSign(Action clickType, Sign sign, Player player, Optional<Craft> craft);
+    public abstract boolean processSignChange(SignChangeEvent event);
+
 }

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractMovecraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractMovecraftSign.java
@@ -1,0 +1,2 @@
+package net.countercraft.movecraft.sign;public class AbstractMovecraftSign {
+}


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
This PR is a attempt at redoing signs in a more organized way. 
That encompasses the following things:
- Signs get registered to a central registry / map
- A single listener retrieves the fitting registered sign and calls those for processing
- Signs can be overridden, useful for addons that want to change behaviors of let's say move signs (e.g. Squadrons reloaded)
- Removes redundant code and should make it cleaner
- Should make remote sign implementations much cleaner cause that way one can just call the relevant registered sign instead of firing a new event

TODO List:
- [x] Base class for signs
- [x] Base class for "craft signs" (everything that *requires* a craft and that can react to craft detection and sign translation)
- [x] Sign registration
- [x] Sign retrieval by "ID"
- [ ] AbstractCruiseSign => will be the base class for signs acting similar to the cruise sign
- [ ] Re-Implement existing signs
  - [ ] Ascend sign
  - [ ] Descend sign
  - [ ] Cruise sign
  - [ ] Helm sign
  - [ ] Name sign
  - [ ] Move sign
  - [ ] Pilot sign
  - [ ] RelativeMove sign
  - [ ] Release sign
  - [ ] Remote sign => will receive rework to better handle multiple target signs and to avoid beavering
  - [ ] Scuttle sign
  - [ ] Speed sign
  - [ ] SubcraftRotate => will maybe receive a rework so it is more reliable and less prone to beavering
  - [ ] Teleport sign
  - [ ] **NEW** Subcraft Move

### Checklist
- [ ] Proper internationalization
- [ ] Tested
- [ ] Performance tested (could improve performance on remote signs and subcraft, not done yet)
