### PR TITLE
Feature/direction dependent block attachment

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
@@ -355,14 +355,13 @@ public class DetectionTask implements Supplier<Effect> {
             while((probe = currentFrontier.poll()) != null) {
                 BlockData blockData = movecraftWorld.getData(probe);
                 Material material = blockData.getMaterial();
-                boolean blockFacingCraft = true;
 
                 if (material == Material.LADDER) {
                     BlockFace facing = ((Directional) blockData).getFacing().getOppositeFace();
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
                     if (!legal.contains(relativeLoc)) {
-                        blockFacingCraft = false; // Invalidate block if it's not facing the craft
+                        continue; // Invalidate block if it's not facing the craft
                     }
                 } else if (blockData instanceof FaceAttachable attachable) {
                     FaceAttachable.AttachedFace attachedFace = attachable.getAttachedFace();
@@ -370,20 +369,15 @@ public class DetectionTask implements Supplier<Effect> {
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
                     if (!legal.contains(relativeLoc)) {
-                        blockFacingCraft = false; // Invalidate block if it's not facing the craft
+                        continue; // Invalidate block if it's not facing the craft
                     }
                 } else if (blockData instanceof Lantern lantern) {
                     BlockFace facing = toBlockFace(lantern);
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
                     if (!legal.contains(relativeLoc)) {
-                        blockFacingCraft = false; // Invalidate block if it's not facing the craft
+                        continue; // Invalidate block if it's not facing the craft
                     }
-                }
-
-                if (!blockFacingCraft) {
-                    Bukkit.getLogger().info("Skipped");
-                    continue;
                 }
 
                 if(!visited.add(probe))

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
@@ -309,7 +309,6 @@ public class DetectionTask implements Supplier<Effect> {
         ConcurrentLinkedQueue<MovecraftLocation> nextFrontier = new ConcurrentLinkedQueue<>();
         currentFrontier.add(startLocation);
         currentFrontier.addAll(Arrays.stream(SHIFTS).map(startLocation::add).collect(Collectors.toList()));
-        //visited.addAll(currentFrontier);
         int threads = Runtime.getRuntime().availableProcessors();
         while(!currentFrontier.isEmpty() && size.intValue() < type.getIntProperty(CraftType.MAX_SIZE) + threads) {
             List<ForkJoinTask<?>> tasks = new ArrayList<>();

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
@@ -41,9 +41,6 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.Directional;
-import org.bukkit.block.data.FaceAttachable;
-import org.bukkit.block.data.type.Lantern;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,6 +53,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -356,28 +354,13 @@ public class DetectionTask implements Supplier<Effect> {
                 BlockData blockData = movecraftWorld.getData(probe);
                 Material material = blockData.getMaterial();
 
-                if (material == Material.LADDER) {
-                    BlockFace facing = ((Directional) blockData).getFacing().getOppositeFace();
+                Optional<BlockFace> blockDataOptional = SupportUtils.getSupportFace(blockData);
+                if (blockDataOptional.isPresent()) {
+                    BlockFace facing = blockDataOptional.get();
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
-                    if (!legal.contains(relativeLoc)) {
-                        continue; // Invalidate block if it's not facing the craft
-                    }
-                } else if (blockData instanceof FaceAttachable attachable) {
-                    FaceAttachable.AttachedFace attachedFace = attachable.getAttachedFace();
-                    BlockFace facing = toBlockFace(attachedFace, blockData);
-                    MovecraftLocation relativeLoc = probe.getRelative(facing);
-
-                    if (!legal.contains(relativeLoc)) {
-                        continue; // Invalidate block if it's not facing the craft
-                    }
-                } else if (blockData instanceof Lantern lantern) {
-                    BlockFace facing = toBlockFace(lantern);
-                    MovecraftLocation relativeLoc = probe.getRelative(facing);
-
-                    if (!legal.contains(relativeLoc)) {
-                        continue; // Invalidate block if it's not facing the craft
-                    }
+                    if (!legal.contains(relativeLoc))
+                        continue;
                 }
 
                 if(!visited.add(probe))
@@ -405,18 +388,6 @@ public class DetectionTask implements Supplier<Effect> {
                     audience.sendMessage(Component.text(result.getMessage()));
                 }
             }
-        }
-
-        private BlockFace toBlockFace(FaceAttachable.AttachedFace attachedFace, BlockData bd) {
-            return switch (attachedFace) {
-                case FLOOR -> BlockFace.DOWN;
-                case WALL -> ((Directional) bd).getFacing().getOppositeFace();
-                case CEILING -> BlockFace.UP;
-            };
-        }
-
-        private BlockFace toBlockFace(Lantern hangable) {
-            return hangable.isHanging() ? BlockFace.UP : BlockFace.DOWN;
         }
     }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
@@ -353,26 +353,26 @@ public class DetectionTask implements Supplier<Effect> {
             MovecraftLocation probe;
 
             while((probe = currentFrontier.poll()) != null) {
-                BlockData bd = movecraftWorld.getData(probe);
-                Material m = bd.getMaterial();
+                BlockData blockData = movecraftWorld.getData(probe);
+                Material material = blockData.getMaterial();
                 boolean blockFacingCraft = true;
 
-                if (m == Material.LADDER) {
-                    BlockFace facing = ((Directional) bd).getFacing().getOppositeFace();
+                if (material == Material.LADDER) {
+                    BlockFace facing = ((Directional) blockData).getFacing().getOppositeFace();
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
                     if (!legal.contains(relativeLoc)) {
                         blockFacingCraft = false; // Invalidate block if it's not facing the craft
                     }
-                } else if (bd instanceof FaceAttachable attachable) {
+                } else if (blockData instanceof FaceAttachable attachable) {
                     FaceAttachable.AttachedFace attachedFace = attachable.getAttachedFace();
-                    BlockFace facing = toBlockFace(attachedFace, bd);
+                    BlockFace facing = toBlockFace(attachedFace, blockData);
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
                     if (!legal.contains(relativeLoc)) {
                         blockFacingCraft = false; // Invalidate block if it's not facing the craft
                     }
-                } else if (bd instanceof Lantern lantern) {
+                } else if (blockData instanceof Lantern lantern) {
                     BlockFace facing = toBlockFace(lantern);
                     MovecraftLocation relativeLoc = probe.getRelative(facing);
 
@@ -389,7 +389,7 @@ public class DetectionTask implements Supplier<Effect> {
                 if(!visited.add(probe))
                     continue;
 
-                visitedMaterials.computeIfAbsent(m, Functions.forSupplier(ConcurrentLinkedDeque::new)).add(probe);
+                visitedMaterials.computeIfAbsent(material, Functions.forSupplier(ConcurrentLinkedDeque::new)).add(probe);
                 if(!ALLOWED_BLOCK_VALIDATOR.validate(probe, type, movecraftWorld, player).isSucess())
                     continue;
 
@@ -402,11 +402,11 @@ public class DetectionTask implements Supplier<Effect> {
                 }
 
                 legal.add(probe);
-                if (Tags.FLUID.contains(m))
+                if (Tags.FLUID.contains(material))
                     fluid.add(probe);
 
                 size.increment();
-                materials.computeIfAbsent(m, Functions.forSupplier(ConcurrentLinkedDeque::new)).add(probe);
+                materials.computeIfAbsent(material, Functions.forSupplier(ConcurrentLinkedDeque::new)).add(probe);
                 for (MovecraftLocation shift : SHIFTS) {
                     var shifted = probe.add(shift);
                     nextFrontier.add(shifted);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
@@ -389,21 +389,20 @@ public class DetectionTask implements Supplier<Effect> {
 
                 var result = chain.validate(probe, type, movecraftWorld, player);
 
-                if (!result.isSucess()) {
+                if (result.isSucess()) {
+                    legal.add(probe);
+                    if (Tags.FLUID.contains(material))
+                        fluid.add(probe);
+
+                    size.increment();
+                    materials.computeIfAbsent(material, Functions.forSupplier(ConcurrentLinkedDeque::new)).add(probe);
+                    for (MovecraftLocation shift : SHIFTS) {
+                        var shifted = probe.add(shift);
+                        nextFrontier.add(shifted);
+                    }
+                } else {
                     illegal.add(probe);
                     audience.sendMessage(Component.text(result.getMessage()));
-                    return;
-                }
-
-                legal.add(probe);
-                if (Tags.FLUID.contains(material))
-                    fluid.add(probe);
-
-                size.increment();
-                materials.computeIfAbsent(material, Functions.forSupplier(ConcurrentLinkedDeque::new)).add(probe);
-                for (MovecraftLocation shift : SHIFTS) {
-                    var shifted = probe.add(shift);
-                    nextFrontier.add(shifted);
                 }
             }
         }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/DetectionTask.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -349,12 +350,13 @@ public class DetectionTask implements Supplier<Effect> {
         @Override
         public void run() {
             MovecraftLocation probe;
+            EnumSet<Material> directionalDependent = type.getMaterialSetProperty(CraftType.DIRECTIONAL_DEPENDENT_MATERIALS);
 
             while((probe = currentFrontier.poll()) != null) {
                 BlockData blockData = movecraftWorld.getData(probe);
                 Material material = blockData.getMaterial();
 
-                Optional<BlockFace> blockDataOptional = SupportUtils.getSupportFace(blockData);
+                Optional<BlockFace> blockDataOptional = SupportUtils.getSupportFace(blockData, directionalDependent);
                 if (blockDataOptional.isPresent()) {
                     BlockFace facing = blockDataOptional.get();
                     MovecraftLocation relativeLoc = probe.getRelative(facing);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/SupportUtils.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/SupportUtils.java
@@ -22,15 +22,12 @@ public class SupportUtils {
             return Optional.of(face);
         }
 
-        //This should become Hangable instead when we drop support for 1.18
+        //TODO: Use pattern matched switch statements once we update do Java 21
+        //TODO: This should become Hangable instead when we drop support for 1.18
         if (data instanceof Lantern lantern)
             return Optional.of(lantern.isHanging() ? BlockFace.UP : BlockFace.DOWN);
 
-        if (data instanceof FaceAttachable faceAttachable) {
-            //this cast should never fail as the only blocks that implement FaceAttachable
-            //are also directional: Switch(Lever) and Grindstone
-            Directional directional = (Directional) data;
-
+        if (data instanceof FaceAttachable faceAttachable && data instanceof Directional directional) {
             return switch (faceAttachable.getAttachedFace()) {
                 case FLOOR -> Optional.of(BlockFace.DOWN);
                 case WALL -> Optional.of(directional.getFacing().getOppositeFace());

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/SupportUtils.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/tasks/detection/SupportUtils.java
@@ -1,0 +1,43 @@
+package net.countercraft.movecraft.processing.tasks.detection;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
+import org.bukkit.block.data.FaceAttachable;
+import org.bukkit.block.data.type.Lantern;
+
+import java.util.Optional;
+
+/**
+ * @author Intybyte/Vaan1310
+ * An util craft that uses block data to get its supporting block
+ */
+
+public class SupportUtils {
+    public static Optional<BlockFace> getSupportFace(BlockData data) {
+
+        if (data.getMaterial() == Material.LADDER) {
+            BlockFace face = ((Directional) data).getFacing().getOppositeFace();
+            return Optional.of(face);
+        }
+
+        //This should become Hangable instead when we drop support for 1.18
+        if (data instanceof Lantern lantern)
+            return Optional.of(lantern.isHanging() ? BlockFace.UP : BlockFace.DOWN);
+
+        if (data instanceof FaceAttachable faceAttachable) {
+            //this cast should never fail as the only blocks that implement FaceAttachable
+            //are also directional: Switch(Lever) and Grindstone
+            Directional directional = (Directional) data;
+
+            return switch (faceAttachable.getAttachedFace()) {
+                case FLOOR -> Optional.of(BlockFace.DOWN);
+                case WALL -> Optional.of(directional.getFacing().getOppositeFace());
+                case CEILING -> Optional.of(BlockFace.UP);
+            };
+        }
+
+        return Optional.empty();
+    }
+}

--- a/api/src/main/java/net/countercraft/movecraft/MovecraftLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/MovecraftLocation.java
@@ -20,6 +20,7 @@ package net.countercraft.movecraft;
 import com.google.common.primitives.UnsignedInteger;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.BlockFace;
 import org.jetbrains.annotations.NotNull;
 
 import static net.countercraft.movecraft.util.BitMath.mask;
@@ -153,5 +154,9 @@ final public class MovecraftLocation implements Comparable<MovecraftLocation>{
             return this.z - other.z ;
         }
         return 0;
+    }
+
+    public MovecraftLocation getRelative(BlockFace facing) {
+        return this.translate(facing.getModX(), facing.getModY(), facing.getModZ());
     }
 }

--- a/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
@@ -53,6 +53,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -189,6 +190,7 @@ final public class CraftType {
     public static final NamespacedKey CRUISE_ON_PILOT_LIFETIME = buildKey("cruise_on_pilot_lifetime");
 
     public static final NamespacedKey EXPLOSION_ARMING_TIME = buildKey("explosion_arming_time");
+    public static final NamespacedKey DIRECTIONAL_DEPENDENT_MATERIALS = buildKey("directional_dependent_materials");
     //endregion
 
     @Contract("_ -> new")
@@ -391,6 +393,13 @@ final public class CraftType {
         /* Optional properties */
         registerProperty(new RequiredBlockProperty("flyblocks", FLY_BLOCKS, type -> new HashSet<>()));
         registerProperty(new RequiredBlockProperty("detectionblocks", DETECTION_BLOCKS, type -> new HashSet<>()));
+        registerProperty(new MaterialSetProperty("directionDependentMaterials", DIRECTIONAL_DEPENDENT_MATERIALS, type -> {
+            var set = EnumSet.of(Material.LADDER, Material.TORCH, Material.LEVER, Material.GRINDSTONE, Material.LANTERN);
+            //add all Signs (maybe there is a better way to do it?)
+            Arrays.stream(Material.values()).filter(mat -> mat.name().endsWith("_SIGN")).forEach(set::add);
+            return set;
+        }));
+
         registerProperty(new ObjectPropertyImpl("forbiddenSignStrings", FORBIDDEN_SIGN_STRINGS,
                 (data, type, fileKey, namespacedKey) -> data.getStringListOrEmpty(fileKey).stream().map(
                         String::toLowerCase).collect(Collectors.toSet()),

--- a/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
@@ -396,7 +396,7 @@ final public class CraftType {
         registerProperty(new MaterialSetProperty("directionDependentMaterials", DIRECTIONAL_DEPENDENT_MATERIALS, type -> {
             var set = EnumSet.of(Material.LADDER, Material.TORCH, Material.LEVER, Material.GRINDSTONE, Material.LANTERN);
             //add all Signs (maybe there is a better way to do it?)
-            Arrays.stream(Material.values()).filter(mat -> mat.name().endsWith("_SIGN")).forEach(set::add);
+            Arrays.stream(Material.values()).filter(mat -> mat.name().endsWith("WALL_SIGN")).forEach(set::add);
             return set;
         }));
 

--- a/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -391,9 +390,9 @@ final public class CraftType {
         registerProperty(new RequiredBlockProperty("flyblocks", FLY_BLOCKS, type -> new HashSet<>()));
         registerProperty(new RequiredBlockProperty("detectionblocks", DETECTION_BLOCKS, type -> new HashSet<>()));
         registerProperty(new MaterialSetProperty("directionDependentMaterials", DIRECTIONAL_DEPENDENT_MATERIALS, type -> {
-            var set = EnumSet.of(Material.LADDER, Material.TORCH, Material.LEVER, Material.GRINDSTONE, Material.LANTERN);
-            //add all Signs (maybe there is a better way to do it?)
+            var set = EnumSet.of(Material.LADDER, Material.LEVER, Material.GRINDSTONE, Material.LANTERN);
             set.addAll(Tag.WALL_SIGNS.getValues());
+            set.addAll(Tags.WALL_TORCHES);
             return set;
         }));
 

--- a/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/type/CraftType.java
@@ -43,10 +43,7 @@ import net.countercraft.movecraft.util.Pair;
 import net.countercraft.movecraft.util.Tags;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.World;
+import org.bukkit.*;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -396,7 +393,7 @@ final public class CraftType {
         registerProperty(new MaterialSetProperty("directionDependentMaterials", DIRECTIONAL_DEPENDENT_MATERIALS, type -> {
             var set = EnumSet.of(Material.LADDER, Material.TORCH, Material.LEVER, Material.GRINDSTONE, Material.LANTERN);
             //add all Signs (maybe there is a better way to do it?)
-            Arrays.stream(Material.values()).filter(mat -> mat.name().endsWith("WALL_SIGN")).forEach(set::add);
+            set.addAll(Tag.WALL_SIGNS.getValues());
             return set;
         }));
 

--- a/api/src/main/java/net/countercraft/movecraft/util/Tags.java
+++ b/api/src/main/java/net/countercraft/movecraft/util/Tags.java
@@ -4,14 +4,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.Registry;
 import org.bukkit.Tag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Set;
 
 public class Tags {
     public static final EnumSet<Material> WATER = EnumSet.of(Material.WATER, Material.BUBBLE_COLUMN);
@@ -22,6 +19,7 @@ public class Tags {
     public static final EnumSet<Material> FRAGILE_MATERIALS = EnumSet.noneOf(Material.class);
     public static final EnumSet<Material> FALL_THROUGH_BLOCKS = EnumSet.noneOf(Material.class);
     public static final EnumSet<Material> BUCKETS = EnumSet.of(Material.LAVA_BUCKET, Material.WATER_BUCKET, Material.MILK_BUCKET, Material.COD_BUCKET, Material.PUFFERFISH_BUCKET, Material.SALMON_BUCKET, Material.TROPICAL_FISH_BUCKET);
+    public static final EnumSet<Material> WALL_TORCHES = EnumSet.of(Material.WALL_TORCH, Material.SOUL_WALL_TORCH, Material.REDSTONE_WALL_TORCH);
 
     static {
         FRAGILE_MATERIALS.add(Material.PISTON_HEAD);


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
When detecting a craft it checks if it is a block like a ladder, lantern on an attachable block, if said blocks aren't attached to the craft, then don't add them to the craft.

### Related issues:
Fix #430

### Checklist
- [x] Tested
