### PR TITLE
Refine craft data tag system

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -57,7 +57,6 @@ public class Movecraft extends JavaPlugin {
     private WorldHandler worldHandler;
     private SmoothTeleport smoothTeleport;
     private AsyncManager asyncManager;
-    private CraftDataTagRegistry craftDataTagRegistry;
 
     public static synchronized Movecraft getInstance() {
         return instance;
@@ -188,10 +187,6 @@ public class Movecraft extends JavaPlugin {
         boolean datapackInitialized = isDatapackEnabled() || initializeDatapack();
         asyncManager = new AsyncManager();
         asyncManager.runTaskTimer(this, 0, 1);
-
-        craftDataTagRegistry = new CraftDataTagRegistry();
-
-
         MapUpdateManager.getInstance().runTaskTimer(this, 0, 1);
 
         CraftManager.initialize(datapackInitialized);
@@ -336,9 +331,5 @@ public class Movecraft extends JavaPlugin {
 
     public AsyncManager getAsyncManager() {
         return asyncManager;
-    }
-
-    public CraftDataTagRegistry getCraftDataTagRegistry() {
-        return craftDataTagRegistry;
     }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -23,6 +23,7 @@ import net.countercraft.movecraft.commands.*;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.ChunkManager;
 import net.countercraft.movecraft.craft.CraftManager;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagRegistry;
 import net.countercraft.movecraft.features.contacts.ContactsCommand;
 import net.countercraft.movecraft.features.contacts.ContactsManager;
 import net.countercraft.movecraft.features.contacts.ContactsSign;
@@ -38,6 +39,7 @@ import net.countercraft.movecraft.util.Tags;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -55,6 +57,7 @@ public class Movecraft extends JavaPlugin {
     private WorldHandler worldHandler;
     private SmoothTeleport smoothTeleport;
     private AsyncManager asyncManager;
+    private CraftDataTagRegistry craftDataTagRegistry;
 
     public static synchronized Movecraft getInstance() {
         return instance;
@@ -185,6 +188,10 @@ public class Movecraft extends JavaPlugin {
         boolean datapackInitialized = isDatapackEnabled() || initializeDatapack();
         asyncManager = new AsyncManager();
         asyncManager.runTaskTimer(this, 0, 1);
+
+        craftDataTagRegistry = new CraftDataTagRegistry();
+
+
         MapUpdateManager.getInstance().runTaskTimer(this, 0, 1);
 
         CraftManager.initialize(datapackInitialized);
@@ -329,5 +336,9 @@ public class Movecraft extends JavaPlugin {
 
     public AsyncManager getAsyncManager() {
         return asyncManager;
+    }
+
+    public CraftDataTagRegistry getCraftDataTagRegistry() {
+        return craftDataTagRegistry;
     }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -537,10 +537,8 @@ public abstract class BaseCraft implements Craft {
     }
 
     @Override
-    public <T> boolean setDataTag(CraftDataTagKey<T> tagKey, T data) {
+    public <T> void setDataTag(CraftDataTagKey<T> tagKey, T data) {
         dataTagContainer.set(tagKey, data);
-
-        return true;
     }
 
     @Override

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -80,7 +80,8 @@ public abstract class BaseCraft implements Craft {
     private MovecraftLocation lastTranslation = new MovecraftLocation(0, 0, 0);
     private Map<NamespacedKey, Set<TrackedLocation>> trackedLocations = new HashMap<>();
 
-    private final CraftDataTagContainer dataTagContainer = new CraftDataTagContainer();
+    @NotNull
+    private final CraftDataTagContainer dataTagContainer;
 
     private final UUID uuid = UUID.randomUUID();
 
@@ -96,6 +97,7 @@ public abstract class BaseCraft implements Craft {
         disabled = false;
         origPilotTime = System.currentTimeMillis();
         audience = Audience.empty();
+        dataTagContainer = new CraftDataTagContainer(Movecraft.getInstance().getCraftDataTagRegistry());
     }
 
 

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -23,13 +23,23 @@ import net.countercraft.movecraft.util.hitboxes.MutableHitBox;
 import net.countercraft.movecraft.util.hitboxes.SetHitBox;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -537,12 +547,12 @@ public abstract class BaseCraft implements Craft {
     }
 
     @Override
-    public <T> void setDataTag(CraftDataTagKey<T> tagKey, T data) {
+    public <T> void setDataTag(final @NotNull CraftDataTagKey<T> tagKey, final T data) {
         dataTagContainer.set(tagKey, data);
     }
 
     @Override
-    public <T> T getDataTag(CraftDataTagKey<T> tagKey) {
+    public <T> T getDataTag(final @NotNull CraftDataTagKey<T> tagKey) {
         return dataTagContainer.get(this, tagKey);
     }
 

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -9,6 +9,7 @@ import net.countercraft.movecraft.async.rotation.RotationTask;
 import net.countercraft.movecraft.async.translation.TranslationTask;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagContainer;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagKey;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.processing.CachedMovecraftWorld;
@@ -536,8 +537,15 @@ public abstract class BaseCraft implements Craft {
     }
 
     @Override
-    public CraftDataTagContainer getDataTagContainer() {
-        return dataTagContainer;
+    public <T> boolean setDataTag(CraftDataTagKey<T> tagKey, T data) {
+        dataTagContainer.set(tagKey, data);
+
+        return true;
+    }
+
+    @Override
+    public <T> T getDataTag(CraftDataTagKey<T> tagKey) {
+        return dataTagContainer.get(this, tagKey);
     }
 
     @Override

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -10,6 +10,7 @@ import net.countercraft.movecraft.async.translation.TranslationTask;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagContainer;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagKey;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagRegistry;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.localisation.I18nSupport;
 import net.countercraft.movecraft.processing.CachedMovecraftWorld;
@@ -97,7 +98,7 @@ public abstract class BaseCraft implements Craft {
         disabled = false;
         origPilotTime = System.currentTimeMillis();
         audience = Audience.empty();
-        dataTagContainer = new CraftDataTagContainer(Movecraft.getInstance().getCraftDataTagRegistry());
+        dataTagContainer = new CraftDataTagContainer();
     }
 
 

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/contacts/ContactsManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/contacts/ContactsManager.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class ContactsManager extends BukkitRunnable implements Listener {
-    private static final CraftDataTagKey<Map<Craft, Long>> RECENT_CONTACTS = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "recent-contacts"), craft -> new WeakHashMap<>());
+    private static final CraftDataTagKey<Map<Craft, Long>> RECENT_CONTACTS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "recent-contacts"), craft -> new WeakHashMap<>());
 
     @Override
     public void run() {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/contacts/ContactsManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/contacts/ContactsManager.java
@@ -4,6 +4,7 @@ import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.*;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagContainer;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagKey;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagRegistry;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.*;
 import net.countercraft.movecraft.exception.EmptyHitBoxException;
@@ -27,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class ContactsManager extends BukkitRunnable implements Listener {
-    private static final CraftDataTagKey<Map<Craft, Long>> RECENT_CONTACTS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "recent-contacts"), craft -> new WeakHashMap<>());
+    private static final CraftDataTagKey<Map<Craft, Long>> RECENT_CONTACTS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "recent-contacts"), craft -> new WeakHashMap<>());
 
     @Override
     public void run() {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class StatusManager extends BukkitRunnable implements Listener {
-    private static final CraftDataTagKey<Long> LAST_STATUS_CHECK = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "last-status-check"), craft -> System.currentTimeMillis());
+    private static final CraftDataTagKey<Long> LAST_STATUS_CHECK = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "last-status-check"), craft -> System.currentTimeMillis());
 
     @Override
     public void run() {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
@@ -7,6 +7,7 @@ import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.craft.SinkingCraft;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagContainer;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagKey;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagRegistry;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.craft.type.RequiredBlockEntry;
 import net.countercraft.movecraft.features.status.events.CraftStatusUpdateEvent;
@@ -33,7 +34,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class StatusManager extends BukkitRunnable implements Listener {
-    private static final CraftDataTagKey<Long> LAST_STATUS_CHECK = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "last-status-check"), craft -> System.currentTimeMillis());
+    private static final CraftDataTagKey<Long> LAST_STATUS_CHECK = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "last-status-check"), craft -> System.currentTimeMillis());
 
     @Override
     public void run() {

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -43,11 +43,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public interface Craft {
-    CraftDataTagKey<List<Craft>> CONTACTS = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "contacts"), craft -> new ArrayList<>(0));
-    CraftDataTagKey<Double> FUEL = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "fuel"), craft -> 0D);
-    CraftDataTagKey<Counter<Material>> MATERIALS = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "materials"), craft -> new Counter<>());
-    CraftDataTagKey<Integer> NON_NEGLIGIBLE_BLOCKS = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "non-negligible-blocks"), Craft::getOrigBlockCount);
-    CraftDataTagKey<Integer> NON_NEGLIGIBLE_SOLID_BLOCKS = CraftDataTagContainer.tryRegisterTagKey(new NamespacedKey("movecraft", "non-negligible-solid-blocks"), Craft::getOrigBlockCount);
+    CraftDataTagKey<List<Craft>> CONTACTS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "contacts"), craft -> new ArrayList<>(0));
+    CraftDataTagKey<Double> FUEL = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "fuel"), craft -> 0D);
+    CraftDataTagKey<Counter<Material>> MATERIALS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "materials"), craft -> new Counter<>());
+    CraftDataTagKey<Integer> NON_NEGLIGIBLE_BLOCKS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "non-negligible-blocks"), Craft::getOrigBlockCount);
+    CraftDataTagKey<Integer> NON_NEGLIGIBLE_SOLID_BLOCKS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "non-negligible-solid-blocks"), Craft::getOrigBlockCount);
 
     // Java disallows private or protected fields in interfaces, this is a workaround
     class Hidden {

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -272,8 +272,9 @@ public interface Craft {
 
     void setAudience(Audience audience);
 
-    <T> void setDataTag(CraftDataTagKey<T> tagKey, T data);
-    <T> T getDataTag(CraftDataTagKey<T> tagKey);
+    <T> void setDataTag(@NotNull final CraftDataTagKey<T> tagKey, final T data);
+
+    <T> T getDataTag(@NotNull final CraftDataTagKey<T> tagKey);
 
     public default void markTileStateWithUUID(TileState tile) {
         // Add the marker

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -272,25 +272,8 @@ public interface Craft {
 
     void setAudience(Audience audience);
 
-    public default CraftDataTagContainer getDataTagContainer() {
-        return null;
-    }
-
-    public default <T> boolean setDataTag(CraftDataTagKey<T> tagKey, T data) {
-        CraftDataTagContainer container = this.getDataTagContainer();
-        if (container == null) {
-            return false;
-        }
-        container.set(tagKey, data);
-        return true;
-    }
-    public default <T> T getDataTag(CraftDataTagKey<T> tagKey) {
-        CraftDataTagContainer container = this.getDataTagContainer();
-        if (container == null) {
-            return null;
-        }
-        return container.get(this, tagKey);
-    }
+    <T> boolean setDataTag(CraftDataTagKey<T> tagKey, T data);
+    <T> T getDataTag(CraftDataTagKey<T> tagKey);
 
     public default void markTileStateWithUUID(TileState tile) {
         // Add the marker

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -272,7 +272,7 @@ public interface Craft {
 
     void setAudience(Audience audience);
 
-    <T> boolean setDataTag(CraftDataTagKey<T> tagKey, T data);
+    <T> void setDataTag(CraftDataTagKey<T> tagKey, T data);
     <T> T getDataTag(CraftDataTagKey<T> tagKey);
 
     public default void markTileStateWithUUID(TileState tile) {

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -23,6 +23,7 @@ import net.countercraft.movecraft.MovecraftRotation;
 import net.countercraft.movecraft.TrackedLocation;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagContainer;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagKey;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagRegistry;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.processing.MovecraftWorld;
 import net.countercraft.movecraft.util.Counter;
@@ -43,11 +44,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public interface Craft {
-    CraftDataTagKey<List<Craft>> CONTACTS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "contacts"), craft -> new ArrayList<>(0));
-    CraftDataTagKey<Double> FUEL = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "fuel"), craft -> 0D);
-    CraftDataTagKey<Counter<Material>> MATERIALS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "materials"), craft -> new Counter<>());
-    CraftDataTagKey<Integer> NON_NEGLIGIBLE_BLOCKS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "non-negligible-blocks"), Craft::getOrigBlockCount);
-    CraftDataTagKey<Integer> NON_NEGLIGIBLE_SOLID_BLOCKS = CraftDataTagContainer.registerTagKey(new NamespacedKey("movecraft", "non-negligible-solid-blocks"), Craft::getOrigBlockCount);
+    CraftDataTagKey<List<Craft>> CONTACTS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "contacts"), craft -> new ArrayList<>(0));
+    CraftDataTagKey<Double> FUEL = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "fuel"), craft -> 0D);
+    CraftDataTagKey<Counter<Material>> MATERIALS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "materials"), craft -> new Counter<>());
+    CraftDataTagKey<Integer> NON_NEGLIGIBLE_BLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "non-negligible-blocks"), Craft::getOrigBlockCount);
+    CraftDataTagKey<Integer> NON_NEGLIGIBLE_SOLID_BLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "non-negligible-solid-blocks"), Craft::getOrigBlockCount);
 
     // Java disallows private or protected fields in interfaces, this is a workaround
     class Hidden {

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -13,7 +13,7 @@ public class CraftDataTagContainer extends HashMap<CraftDataTagKey<?>, Object> {
 
     public static final Map<NamespacedKey, CraftDataTagKey<?>> REGISTERED_TAGS = new HashMap<>();
 
-    public static <T> CraftDataTagKey<T> tryRegisterTagKey(final NamespacedKey key, final Function<Craft, T> supplier) throws IllegalArgumentException {
+    public static <T> @NotNull CraftDataTagKey<T> tryRegisterTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
         if (REGISTERED_TAGS.containsKey(key)) {
             throw new IllegalArgumentException("Duplicate keys are not allowed!");
         } else {

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -19,7 +19,7 @@ public class CraftDataTagContainer {
         _backing = new ConcurrentHashMap<>();
     }
 
-    public static final Map<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new HashMap<>();
+    public static final ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new ConcurrentHashMap<>();
 
     public static <T> @NotNull CraftDataTagKey<T> tryRegisterTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
         if (REGISTERED_TAGS.containsKey(key)) {

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -3,21 +3,29 @@ package net.countercraft.movecraft.craft.datatag;
 import net.countercraft.movecraft.craft.Craft;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public class CraftDataTagContainer extends HashMap<CraftDataTagKey<?>, Object> {
+public class CraftDataTagContainer {
+    private final @NotNull ConcurrentMap<@NotNull CraftDataTagKey<?>, @Nullable Object> _backing;
 
-    public static final Map<NamespacedKey, CraftDataTagKey<?>> REGISTERED_TAGS = new HashMap<>();
+    public CraftDataTagContainer(){
+        _backing = new ConcurrentHashMap<>();
+    }
+
+    public static final Map<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new HashMap<>();
 
     public static <T> @NotNull CraftDataTagKey<T> tryRegisterTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
         if (REGISTERED_TAGS.containsKey(key)) {
             throw new IllegalArgumentException("Duplicate keys are not allowed!");
         } else {
-            CraftDataTagKey<T> result = new CraftDataTagKey<T>(key, supplier);
+            CraftDataTagKey<T> result = new CraftDataTagKey<>(key, supplier);
             REGISTERED_TAGS.put(key, result);
             return result;
         }
@@ -28,26 +36,26 @@ public class CraftDataTagContainer extends HashMap<CraftDataTagKey<?>, Object> {
             // TODO: Log error
             return null;
         }
-        T result = null;
-        if (!this.containsKey(tagKey)) {
+        T result;
+        if (!_backing.containsKey(tagKey)) {
             result = tagKey.createNew(craft);
-            this.put(tagKey, result);
+            _backing.put(tagKey, result);
         } else {
-            Object stored = this.getOrDefault(tagKey, tagKey.createNew(craft));
+            Object stored = _backing.getOrDefault(tagKey, tagKey.createNew(craft));
             try {
                 T temp = (T) stored;
                 result = temp;
             } catch (ClassCastException cce) {
                 // TODO: Log error
                 result = tagKey.createNew(craft);
-                this.put(tagKey, result);
+                _backing.put(tagKey, result);
             }
         }
         return result;
     }
 
     public <T> void set(CraftDataTagKey<T> tagKey, @NotNull T value) {
-        this.put(tagKey, value);
+        _backing.put(tagKey, value);
     }
 
 }

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -1,41 +1,20 @@
 package net.countercraft.movecraft.craft.datatag;
 
 import net.countercraft.movecraft.craft.Craft;
-import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 
 public class CraftDataTagContainer {
-    private static final @NotNull ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new ConcurrentHashMap<>();
-    private final @NotNull ConcurrentMap<@NotNull CraftDataTagKey<?>, @Nullable Object> _backing;
+    private final @NotNull ConcurrentMap<@NotNull CraftDataTagKey<?>, @Nullable Object> backing;
+    private final @NotNull CraftDataTagRegistry registry;
 
-    public CraftDataTagContainer(){
-        _backing = new ConcurrentHashMap<>();
-    }
-
-    /**
-     * Registers a data tag to be attached to craft instances. The data tag will initialize to the value supplied by the
-     * initializer. Once a tag is registered, it can be accessed from crafts using the returned key through various
-     * methods.
-     *
-     * @param key the namespace key to use for registration, which must be unique
-     * @param initializer a default initializer for the value type
-     * @return A CraftDataTagKey, which can be used to control an associated value on a Craft instance
-     * @param <T> the value type
-     * @throws IllegalArgumentException when the provided key is already registered
-     */
-    public static <T> @NotNull CraftDataTagKey<T> registerTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> initializer) throws IllegalArgumentException {
-        CraftDataTagKey<T> result = new CraftDataTagKey<>(key, initializer);
-        var previous = REGISTERED_TAGS.putIfAbsent(key, result);
-        if(previous != null){
-            throw new IllegalArgumentException(String.format("Key %s is already registered.", key));
-        }
-
-        return result;
+    public CraftDataTagContainer(@NotNull CraftDataTagRegistry registry){
+        backing = new ConcurrentHashMap<>();
+        this.registry = Objects.requireNonNull(registry);
     }
 
     /**
@@ -49,11 +28,11 @@ public class CraftDataTagContainer {
      * @throws IllegalStateException when the provided tagKey does not match the underlying tag value
      */
     public <T> T get(final @NotNull Craft craft, @NotNull CraftDataTagKey<T> tagKey) {
-        if (!REGISTERED_TAGS.containsKey(tagKey.key)) {
+        if (!registry.isRegistered(tagKey.key)) {
             throw new IllegalArgumentException(String.format("The provided key %s was not registered.", tagKey));
         }
 
-        Object stored = _backing.computeIfAbsent(tagKey, ignored -> tagKey.createNew(craft));
+        Object stored = backing.computeIfAbsent(tagKey, ignored -> tagKey.createNew(craft));
         try {
             //noinspection unchecked
             return (T) stored;
@@ -70,6 +49,10 @@ public class CraftDataTagContainer {
      * @param <T> the type of the value
      */
     public <T> void set(@NotNull CraftDataTagKey<T> tagKey, @NotNull T value) {
-        _backing.put(tagKey, value);
+        if (!registry.isRegistered(tagKey.key)) {
+            throw new IllegalArgumentException(String.format("The provided key %s was not registered.", tagKey));
+        }
+
+        backing.put(tagKey, value);
     }
 }

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -17,11 +17,22 @@ public class CraftDataTagContainer {
         _backing = new ConcurrentHashMap<>();
     }
 
-    public static <T> @NotNull CraftDataTagKey<T> registerTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
-        CraftDataTagKey<T> result = new CraftDataTagKey<>(key, supplier);
+    /**
+     * Registers a data tag to be attached to craft instances. The data tag will initialize to the value supplied by the
+     * initializer. Once a tag is registered, it can be accessed from crafts using the returned key through various
+     * methods.
+     *
+     * @param key the namespace key to use for registration, which must be unique
+     * @param initializer a default initializer for the value type
+     * @return A CraftDataTagKey, which can be used to control an associated value on a Craft instance
+     * @param <T> the value type
+     * @throws IllegalArgumentException when the provided key is already registered
+     */
+    public static <T> @NotNull CraftDataTagKey<T> registerTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> initializer) throws IllegalArgumentException {
+        CraftDataTagKey<T> result = new CraftDataTagKey<>(key, initializer);
         var previous = REGISTERED_TAGS.putIfAbsent(key, result);
         if(previous != null){
-            throw new IllegalArgumentException("Duplicate keys are not allowed!");
+            throw new IllegalArgumentException(String.format("Key %s is already registered.", key));
         }
 
         return result;
@@ -29,6 +40,7 @@ public class CraftDataTagContainer {
 
     /**
      * Gets the data value associated with the provided tagKey from a craft.
+     *
      * @param craft the craft to perform a lookup against
      * @param tagKey the tagKey to use for looking up the relevant data
      * @return the tag value associate with the provided tagKey on the specified craft
@@ -50,6 +62,13 @@ public class CraftDataTagContainer {
         }
     }
 
+    /**
+     * Set the value associated with the provided tagKey on the associated craft.
+     *
+     * @param tagKey the tagKey to use for storing the relevant data
+     * @param value the value to set for future lookups
+     * @param <T> the type of the value
+     */
     public <T> void set(@NotNull CraftDataTagKey<T> tagKey, @NotNull T value) {
         _backing.put(tagKey, value);
     }

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -10,11 +10,9 @@ import java.util.concurrent.ConcurrentMap;
 
 public class CraftDataTagContainer {
     private final @NotNull ConcurrentMap<@NotNull CraftDataTagKey<?>, @Nullable Object> backing;
-    private final @NotNull CraftDataTagRegistry registry;
 
-    public CraftDataTagContainer(@NotNull CraftDataTagRegistry registry){
+    public CraftDataTagContainer(){
         backing = new ConcurrentHashMap<>();
-        this.registry = Objects.requireNonNull(registry);
     }
 
     /**
@@ -28,7 +26,7 @@ public class CraftDataTagContainer {
      * @throws IllegalStateException when the provided tagKey does not match the underlying tag value
      */
     public <T> T get(final @NotNull Craft craft, @NotNull CraftDataTagKey<T> tagKey) {
-        if (!registry.isRegistered(tagKey.key)) {
+        if (!CraftDataTagRegistry.INSTANCE.isRegistered(tagKey.key)) {
             throw new IllegalArgumentException(String.format("The provided key %s was not registered.", tagKey));
         }
 
@@ -49,7 +47,7 @@ public class CraftDataTagContainer {
      * @param <T> the type of the value
      */
     public <T> void set(@NotNull CraftDataTagKey<T> tagKey, @NotNull T value) {
-        if (!registry.isRegistered(tagKey.key)) {
+        if (!CraftDataTagRegistry.INSTANCE.isRegistered(tagKey.key)) {
             throw new IllegalArgumentException(String.format("The provided key %s was not registered.", tagKey));
         }
 

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -28,7 +28,7 @@ public class CraftDataTagContainer {
     }
 
     /**
-     * Gets the data associate with a provided tagKey from a craft.
+     * Gets the data value associated with the provided tagKey from a craft.
      * @param craft the craft to perform a lookup against
      * @param tagKey the tagKey to use for looking up the relevant data
      * @return the tag value associate with the provided tagKey on the specified craft
@@ -36,7 +36,7 @@ public class CraftDataTagContainer {
      * @throws IllegalArgumentException when the provided tagKey is not registered
      * @throws IllegalStateException when the provided tagKey does not match the underlying tag value
      */
-    public <T> T get(final @NotNull Craft craft, CraftDataTagKey<T> tagKey) {
+    public <T> T get(final @NotNull Craft craft, @NotNull CraftDataTagKey<T> tagKey) {
         if (!REGISTERED_TAGS.containsKey(tagKey.key)) {
             throw new IllegalArgumentException(String.format("The provided key %s was not registered.", tagKey));
         }
@@ -50,8 +50,7 @@ public class CraftDataTagContainer {
         }
     }
 
-    public <T> void set(CraftDataTagKey<T> tagKey, @NotNull T value) {
+    public <T> void set(@NotNull CraftDataTagKey<T> tagKey, @NotNull T value) {
         _backing.put(tagKey, value);
     }
-
 }

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -13,13 +13,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class CraftDataTagContainer {
+    private static final @NotNull ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new ConcurrentHashMap<>();
     private final @NotNull ConcurrentMap<@NotNull CraftDataTagKey<?>, @Nullable Object> _backing;
 
     public CraftDataTagContainer(){
         _backing = new ConcurrentHashMap<>();
     }
-
-    public static final ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new ConcurrentHashMap<>();
 
     public static <T> @NotNull CraftDataTagKey<T> tryRegisterTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
         if (REGISTERED_TAGS.containsKey(key)) {

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -5,12 +5,9 @@ import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class CraftDataTagContainer {
     private static final @NotNull ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> REGISTERED_TAGS = new ConcurrentHashMap<>();
@@ -20,14 +17,14 @@ public class CraftDataTagContainer {
         _backing = new ConcurrentHashMap<>();
     }
 
-    public static <T> @NotNull CraftDataTagKey<T> tryRegisterTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
-        if (REGISTERED_TAGS.containsKey(key)) {
+    public static <T> @NotNull CraftDataTagKey<T> registerTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> supplier) throws IllegalArgumentException {
+        CraftDataTagKey<T> result = new CraftDataTagKey<>(key, supplier);
+        var previous = REGISTERED_TAGS.putIfAbsent(key, result);
+        if(previous != null){
             throw new IllegalArgumentException("Duplicate keys are not allowed!");
-        } else {
-            CraftDataTagKey<T> result = new CraftDataTagKey<>(key, supplier);
-            REGISTERED_TAGS.put(key, result);
-            return result;
         }
+
+        return result;
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagRegistry.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagRegistry.java
@@ -1,0 +1,42 @@
+package net.countercraft.movecraft.craft.datatag;
+
+import net.countercraft.movecraft.craft.Craft;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+public class CraftDataTagRegistry {
+    private final @NotNull ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> _registeredTags;
+
+    public CraftDataTagRegistry(){
+        _registeredTags = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Registers a data tag to be attached to craft instances. The data tag will initialize to the value supplied by the
+     * initializer. Once a tag is registered, it can be accessed from crafts using the returned key through various
+     * methods.
+     *
+     * @param key the namespace key to use for registration, which must be unique
+     * @param initializer a default initializer for the value type
+     * @return A CraftDataTagKey, which can be used to control an associated value on a Craft instance
+     * @param <T> the value type
+     * @throws IllegalArgumentException when the provided key is already registered
+     */
+    public <T> @NotNull CraftDataTagKey<T> registerTagKey(final @NotNull NamespacedKey key, final @NotNull Function<Craft, T> initializer) throws IllegalArgumentException {
+        CraftDataTagKey<T> result = new CraftDataTagKey<>(key, initializer);
+        var previous = _registeredTags.putIfAbsent(key, result);
+        if(previous != null){
+            throw new IllegalArgumentException(String.format("Key %s is already registered.", key));
+        }
+
+        return result;
+    }
+
+    public boolean isRegistered(final @NotNull NamespacedKey key){
+        return _registeredTags.containsKey(key);
+    }
+}

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagRegistry.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagRegistry.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 public class CraftDataTagRegistry {
+    public static final @NotNull CraftDataTagRegistry INSTANCE = new CraftDataTagRegistry();
+
     private final @NotNull ConcurrentMap<@NotNull NamespacedKey, @NotNull CraftDataTagKey<?>> _registeredTags;
 
     public CraftDataTagRegistry(){

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagRegistry.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagRegistry.java
@@ -4,6 +4,8 @@ import net.countercraft.movecraft.craft.Craft;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Enumeration;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -40,5 +42,13 @@ public class CraftDataTagRegistry {
 
     public boolean isRegistered(final @NotNull NamespacedKey key){
         return _registeredTags.containsKey(key);
+    }
+
+    /**
+     * Get an iterable over all keys currently registered.
+     * @return An immutable iterable over the registry keys
+     */
+    public @NotNull Iterable<@NotNull NamespacedKey> getAllKeys(){
+        return _registeredTags.keySet().stream().toList();
     }
 }


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
This PR aims to make improvements to the new `CraftDataTagContainer` system in several areas. While there are API name changes, external consumers should experience no change in behavior under the conditions that were previously required for correct API usage.
 
- Support concurrency
  - The existing implementation does not support concurrent writes to tags, and does not support concurrent registrations
  - The new system is based on `ConcurrentHashMap` instances, and has proper synchronization to yield improved errors
  - The new system does not surface any additional conflict resolution support, but will allow it to be built out in the future
- Reduce internal behavior exposure
  - Favor composition over inheritance for the container object to reduce exposed API surface and allow safely tunning parameters over time
  - Avoid exposing `CraftDataTagContainer` from `Craft` via getter
  - Move system implementation to `BaseCraft`
  - Do not expose the `REGISTERED_TAGS` registry `Map` instance
- Refine error behavior
  - Most locations that return `null` in the case of an error state now throw instead. These states in general are likely to be non-recoverable due to requiring failures during program initialization, i.e. they all required invalid tag registrations
  - Added nullability annotations where applicable
- Improved documentation
  - Updated method names to match method intent (including changes in intent)
  - Added javadoc to `CraftDataTagContainer`
### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [ ] Tested
- [ ] Performance tested <!-- if implementing performance improvements, otherwise delete -->
