### PR TITLE
Use processing for wrecks (again)

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -26,6 +26,7 @@ import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.features.contacts.ContactsCommand;
 import net.countercraft.movecraft.features.contacts.ContactsManager;
 import net.countercraft.movecraft.features.contacts.ContactsSign;
+import net.countercraft.movecraft.features.fading.WreckManager;
 import net.countercraft.movecraft.features.status.StatusManager;
 import net.countercraft.movecraft.features.status.StatusSign;
 import net.countercraft.movecraft.listener.*;
@@ -38,6 +39,7 @@ import net.countercraft.movecraft.util.Tags;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -55,6 +57,7 @@ public class Movecraft extends JavaPlugin {
     private WorldHandler worldHandler;
     private SmoothTeleport smoothTeleport;
     private AsyncManager asyncManager;
+    private WreckManager wreckManager;
 
     public static synchronized Movecraft getInstance() {
         return instance;
@@ -187,8 +190,10 @@ public class Movecraft extends JavaPlugin {
         asyncManager.runTaskTimer(this, 0, 1);
         MapUpdateManager.getInstance().runTaskTimer(this, 0, 1);
 
+
         CraftManager.initialize(datapackInitialized);
         Bukkit.getScheduler().runTaskTimer(this, WorldManager.INSTANCE::run, 0,1);
+        wreckManager = new WreckManager(WorldManager.INSTANCE);
 
         getServer().getPluginManager().registerEvents(new InteractListener(), this);
 
@@ -329,5 +334,9 @@ public class Movecraft extends JavaPlugin {
 
     public AsyncManager getAsyncManager() {
         return asyncManager;
+    }
+
+    public @NotNull WreckManager getWreckManager(){
+        return wreckManager;
     }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -23,24 +23,26 @@ import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.async.rotation.RotationTask;
 import net.countercraft.movecraft.async.translation.TranslationTask;
-import net.countercraft.movecraft.config.Settings;
-import net.countercraft.movecraft.craft.*;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.CraftManager;
+import net.countercraft.movecraft.craft.PilotedCraft;
+import net.countercraft.movecraft.craft.PlayerCraft;
+import net.countercraft.movecraft.craft.SinkingCraft;
 import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
 import net.countercraft.movecraft.mapUpdater.MapUpdateManager;
-import net.countercraft.movecraft.mapUpdater.update.BlockCreateCommand;
-import net.countercraft.movecraft.mapUpdater.update.UpdateCommand;
-import net.countercraft.movecraft.util.hitboxes.HitBox;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -49,13 +51,7 @@ public class AsyncManager extends BukkitRunnable {
     private final Map<AsyncTask, Craft> ownershipMap = new HashMap<>();
     private final BlockingQueue<AsyncTask> finishedAlgorithms = new LinkedBlockingQueue<>();
     private final Set<Craft> clearanceSet = new HashSet<>();
-    private final Map<HitBox, Long> wrecks = new HashMap<>();
-    private final Map<HitBox, World> wreckWorlds = new HashMap<>();
-    private final Map<HitBox, Map<Location, BlockData>> wreckPhases = new HashMap<>();
-    private final Map<World, Set<MovecraftLocation>> processedFadeLocs = new HashMap<>();
     private final Map<Craft, Integer> cooldownCache = new WeakHashMap<>();
-
-    private long lastFadeCheck = 0;
 
     public AsyncManager() {}
 
@@ -69,15 +65,6 @@ public class AsyncManager extends BukkitRunnable {
 
     public void submitCompletedTask(AsyncTask task) {
         finishedAlgorithms.add(task);
-    }
-
-    public void addWreck(Craft craft){
-        if(craft.getCollapsedHitBox().isEmpty() || Settings.FadeWrecksAfter == 0){
-            return;
-        }
-        wrecks.put(craft.getCollapsedHitBox(), System.currentTimeMillis());
-        wreckWorlds.put(craft.getCollapsedHitBox(), craft.getWorld());
-        wreckPhases.put(craft.getCollapsedHitBox(), craft.getPhaseBlocks());
     }
 
     private void processAlgorithmQueue() {
@@ -325,68 +312,11 @@ public class AsyncManager extends BukkitRunnable {
         }
     }
 
-    private void processFadingBlocks() {
-        if (Settings.FadeWrecksAfter == 0)
-            return;
-        long ticksElapsed = (System.currentTimeMillis() - lastFadeCheck) / 50;
-        if (ticksElapsed <= Settings.FadeTickCooldown)
-            return;
-
-        List<HitBox> processed = new ArrayList<>();
-        for(Map.Entry<HitBox, Long> entry : wrecks.entrySet()){
-            if (Settings.FadeWrecksAfter * 1000L > System.currentTimeMillis() - entry.getValue())
-                continue;
-
-            final HitBox hitBox = entry.getKey();
-            final Map<Location, BlockData> phaseBlocks = wreckPhases.get(hitBox);
-            final World world = wreckWorlds.get(hitBox);
-            List<UpdateCommand> commands = new ArrayList<>();
-            int fadedBlocks = 0;
-            if (!processedFadeLocs.containsKey(world))
-                processedFadeLocs.put(world, new HashSet<>());
-
-            int maxFadeBlocks = (int) (hitBox.size() *  (Settings.FadePercentageOfWreckPerCycle / 100.0));
-            //Iterate hitbox as a set to get more random locations
-            for (MovecraftLocation location : hitBox.asSet()){
-                if (processedFadeLocs.get(world).contains(location))
-                    continue;
-
-                if (fadedBlocks >= maxFadeBlocks)
-                    break;
-
-                final Location bLoc = location.toBukkit(world);
-                if ((Settings.FadeWrecksAfter
-                        + Settings.ExtraFadeTimePerBlock.getOrDefault(bLoc.getBlock().getType(), 0))
-                        * 1000L > System.currentTimeMillis() - entry.getValue())
-                    continue;
-
-                fadedBlocks++;
-                processedFadeLocs.get(world).add(location);
-                BlockData phaseBlock = phaseBlocks.getOrDefault(bLoc, Material.AIR.createBlockData());
-                commands.add(new BlockCreateCommand(world, location, phaseBlock));
-            }
-            MapUpdateManager.getInstance().scheduleUpdates(commands);
-            if (!processedFadeLocs.get(world).containsAll(hitBox.asSet()))
-                continue;
-
-            processed.add(hitBox);
-            processedFadeLocs.get(world).removeAll(hitBox.asSet());
-        }
-        for(HitBox hitBox : processed) {
-            wrecks.remove(hitBox);
-            wreckPhases.remove(hitBox);
-            wreckWorlds.remove(hitBox);
-        }
-
-        lastFadeCheck = System.currentTimeMillis();
-    }
-
     public void run() {
         clearAll();
 
         processCruise();
         processSinking();
-        processFadingBlocks();
         processAlgorithmQueue();
 
         // now cleanup craft that are bugged and have not moved in the past 60 seconds,

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -244,7 +244,7 @@ public class CraftManager implements Iterable<Craft>{
                         craft.getHitBox().getMinZ())
                 );
         }
-        Movecraft.getInstance().getAsyncManager().addWreck(craft);
+        Movecraft.getInstance().getWreckManager().queueWreck(craft);
     }
 
     //region Craft management

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/FadeTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/FadeTask.java
@@ -2,11 +2,15 @@ package net.countercraft.movecraft.features.fading;
 
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.processing.MovecraftWorld;
+import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.processing.effects.Effect;
 import net.countercraft.movecraft.processing.effects.SetBlockEffect;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -29,8 +33,10 @@ public class FadeTask implements Supplier<Effect> {
     public Effect get() {
         var testData = world.getData(location);
 
-        return testData.equals(compareData)
-            ? new SetBlockEffect(world, location, setData)
-            : null;
+        return () -> Objects.requireNonNull(Bukkit.getWorld(world.getWorldUUID()))
+            .getChunkAtAsync(location.toBukkit(null))
+            .thenRunAsync(() -> WorldManager.INSTANCE.submit(() -> testData.equals(compareData)
+                ? new SetBlockEffect(world, location, setData)
+                : null));
     }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/FadeTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/FadeTask.java
@@ -9,6 +9,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
 
+/**
+ * Fades a block if the data for the intended block has not been mutated since creation.
+ */
 public class FadeTask implements Supplier<Effect> {
     private final @NotNull BlockData compareData;
     private final @NotNull BlockData setData;

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/FadeTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/FadeTask.java
@@ -1,0 +1,33 @@
+package net.countercraft.movecraft.features.fading;
+
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.processing.MovecraftWorld;
+import net.countercraft.movecraft.processing.effects.Effect;
+import net.countercraft.movecraft.processing.effects.SetBlockEffect;
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
+public class FadeTask implements Supplier<Effect> {
+    private final @NotNull BlockData compareData;
+    private final @NotNull BlockData setData;
+    private final @NotNull MovecraftWorld world;
+    private final @NotNull MovecraftLocation location;
+
+    public FadeTask(@NotNull BlockData compareData, @NotNull BlockData setData, @NotNull MovecraftWorld world, @NotNull MovecraftLocation location){
+        this.compareData = compareData;
+        this.setData = setData;
+        this.world = world;
+        this.location = location;
+    }
+
+    @Override
+    public Effect get() {
+        var testData = world.getData(location);
+
+        return testData.equals(compareData)
+            ? new SetBlockEffect(world, location, setData)
+            : null;
+    }
+}

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckManager.java
@@ -1,0 +1,37 @@
+package net.countercraft.movecraft.features.fading;
+
+import net.countercraft.movecraft.config.Settings;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.processing.WorldManager;
+import net.countercraft.movecraft.util.MathUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class WreckManager {
+    private final @NotNull WorldManager worldManager;
+
+    public WreckManager(@NotNull WorldManager worldManager){
+        this.worldManager = Objects.requireNonNull(worldManager);
+    }
+
+    public void queueWreck(Craft craft){
+        if(craft.getCollapsedHitBox().isEmpty() || Settings.FadeWrecksAfter == 0){
+            return;
+        }
+
+        worldManager.submit(new WreckTask(
+            craft.getCollapsedHitBox(),
+            craft.getMovecraftWorld(),
+            craft
+                .getPhaseBlocks()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    entry -> MathUtils.bukkit2MovecraftLoc(entry.getKey()),
+                    Map.Entry::getValue
+                ))));
+    }
+}

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckManager.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * Singleton for handling wreck disposal
+ */
 public class WreckManager {
     private final @NotNull WorldManager worldManager;
 
@@ -17,7 +20,12 @@ public class WreckManager {
         this.worldManager = Objects.requireNonNull(worldManager);
     }
 
-    public void queueWreck(Craft craft){
+    /**
+     * Queue a wreck to be considered terminally destroyed, and hence appropriate for systems such as fading.
+     *
+     * @param craft the craft to handle as a wreck
+     */
+    public void queueWreck(@NotNull Craft craft){
         if(craft.getCollapsedHitBox().isEmpty() || Settings.FadeWrecksAfter == 0){
             return;
         }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -2,26 +2,18 @@ package net.countercraft.movecraft.features.fading;
 
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
-import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.processing.MovecraftWorld;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.processing.effects.DeferredEffect;
 import net.countercraft.movecraft.processing.effects.Effect;
-import net.countercraft.movecraft.processing.tasks.detection.DetectionTask;
-import net.countercraft.movecraft.util.CollectionUtils;
 import net.countercraft.movecraft.util.CollectorUtils;
-import net.countercraft.movecraft.util.MathUtils;
-import net.countercraft.movecraft.util.hitboxes.BitmapHitBox;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ForkJoinPool;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ForkJoinTask;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -49,7 +49,7 @@ public class WreckTask implements Supplier<Effect> {
         var updates = hitBox
             .asSet()
             .stream()
-            .collect(Collectors.groupingBy(location -> location.scalarMod(16), CollectorUtils.toHitBox()))
+            .collect(Collectors.groupingBy(location -> location.scalarMod(16).hadamardProduct(1,0,1), CollectorUtils.toHitBox()))
             .values()
             .stream()
             .map(slice -> ForkJoinTask.adapt(() -> partialUpdate(slice)))

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -2,19 +2,29 @@ package net.countercraft.movecraft.features.fading;
 
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
+import net.countercraft.movecraft.craft.type.CraftType;
 import net.countercraft.movecraft.processing.MovecraftWorld;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.processing.effects.DeferredEffect;
 import net.countercraft.movecraft.processing.effects.Effect;
+import net.countercraft.movecraft.processing.tasks.detection.DetectionTask;
+import net.countercraft.movecraft.util.CollectionUtils;
+import net.countercraft.movecraft.util.CollectorUtils;
+import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.util.hitboxes.BitmapHitBox;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class WreckTask implements Supplier<Effect> {
 
@@ -36,13 +46,21 @@ public class WreckTask implements Supplier<Effect> {
 
     @Override
     public Effect get() {
-        return partialUpdate();
+        var updates = hitBox
+            .asSet()
+            .stream()
+            .collect(Collectors.groupingBy(location -> location.scalarMod(16), CollectorUtils.toHitBox()))
+            .values()
+            .stream()
+            .map(slice -> ForkJoinTask.adapt(() -> partialUpdate(slice)))
+            .toList();
+
+        return ForkJoinTask.invokeAll(updates).stream().map(ForkJoinTask::join).reduce(Effect.NONE, Effect::andThen);
     }
 
-    public Effect partialUpdate(){
-        // TODO: parallel?
+    public Effect partialUpdate(HitBox slice){
         Effect accumulator = Effect.NONE;
-        for (MovecraftLocation location : hitBox){
+        for (MovecraftLocation location : slice){
             // Get the existing data
             final BlockData data = world.getData(location);
             // Determine the replacement data

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -1,0 +1,59 @@
+package net.countercraft.movecraft.features.fading;
+
+import io.papermc.paper.util.Tick;
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.config.Settings;
+import net.countercraft.movecraft.processing.MovecraftWorld;
+import net.countercraft.movecraft.processing.WorldManager;
+import net.countercraft.movecraft.processing.effects.DeferredEffect;
+import net.countercraft.movecraft.processing.effects.Effect;
+import net.countercraft.movecraft.util.hitboxes.HitBox;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class WreckTask implements Supplier<Effect> {
+
+    private final @NotNull HitBox hitBox;
+    private final @NotNull Map<MovecraftLocation, BlockData> phaseBlocks;
+    private final @NotNull MovecraftWorld world;
+    private final int fadeMaximumTicks;
+
+    public WreckTask(@NotNull HitBox wreck, @NotNull MovecraftWorld world, @NotNull Map<MovecraftLocation, BlockData> phaseBlocks){
+        this.hitBox = Objects.requireNonNull(wreck);
+        this.phaseBlocks = Objects.requireNonNull(phaseBlocks);
+        this.world = Objects.requireNonNull(world);
+
+        int ticks = Tick.tick().fromDuration(Duration.ofSeconds(Settings.FadeWrecksAfter));
+        this.fadeMaximumTicks = (int) (ticks / (Settings.FadePercentageOfWreckPerCycle / 100.0));
+    }
+
+    @Override
+    public Effect get() {
+        return partialUpdate();
+    }
+
+    public Effect partialUpdate(){
+        // TODO: parallel?
+        Effect accumulator = Effect.NONE;
+        for (MovecraftLocation location : hitBox){
+            // Get the existing data
+            final BlockData data = world.getData(location);
+            // Determine the replacement data
+            BlockData replacementData = phaseBlocks.getOrDefault(location, Material.AIR.createBlockData());
+            // Calculate ticks until replacement
+            long fadeTicks = (int) (Math.random() * fadeMaximumTicks);
+            fadeTicks += Settings.ExtraFadeTimePerBlock.getOrDefault(data.getMaterial(), 0);
+            // Deffer replacement until time delay elapses
+            accumulator.andThen(new DeferredEffect(fadeTicks, () -> WorldManager.INSTANCE.submit(new FadeTask(data, replacementData, world, location))));
+        }
+
+        // TODO: Determine if we need to reduce the spread of deferred effects due to runnable overhead
+        return accumulator;
+    }
+}

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -62,7 +62,7 @@ public class WreckTask implements Supplier<Effect> {
             // Calculate ticks until replacement
             long fadeTicks = this.fadeDelayTicks;
             fadeTicks += (int) (Math.random() * maximumFadeDurationTicks);
-            fadeTicks += Settings.ExtraFadeTimePerBlock.getOrDefault(data.getMaterial(), 0);
+            fadeTicks += 20L * Settings.ExtraFadeTimePerBlock.getOrDefault(data.getMaterial(), 0);
             // Deffer replacement until time delay elapses
             accumulator = accumulator.andThen(new DeferredEffect(fadeTicks, () -> WorldManager.INSTANCE.submit(new FadeTask(data, replacementData, world, location))));
         }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -23,17 +23,15 @@ public class WreckTask implements Supplier<Effect> {
     private final @NotNull HitBox hitBox;
     private final @NotNull Map<MovecraftLocation, BlockData> phaseBlocks;
     private final @NotNull MovecraftWorld world;
-    private final int fadeMaximumTicks;
+    private final int fadeDelayTicks;
+    private final int maximumFadeDurationTicks;
 
     public WreckTask(@NotNull HitBox wreck, @NotNull MovecraftWorld world, @NotNull Map<MovecraftLocation, BlockData> phaseBlocks){
         this.hitBox = Objects.requireNonNull(wreck);
         this.phaseBlocks = Objects.requireNonNull(phaseBlocks);
         this.world = Objects.requireNonNull(world);
-
-        // TODO: figure out when Tick class got added
-//        int ticks = Tick.tick().fromDuration(Duration.ofSeconds(Settings.FadeWrecksAfter));
-        int ticks = Settings.FadeWrecksAfter * 20;
-        this.fadeMaximumTicks = (int) (ticks / (Settings.FadePercentageOfWreckPerCycle / 100.0));
+        this.fadeDelayTicks = Settings.FadeWrecksAfter * 20;
+        this.maximumFadeDurationTicks = (int) (Settings.FadeTickCooldown *  (100.0 / Settings.FadePercentageOfWreckPerCycle));
     }
 
     @Override
@@ -62,7 +60,8 @@ public class WreckTask implements Supplier<Effect> {
             // Determine the replacement data
             BlockData replacementData = phaseBlocks.getOrDefault(location, Material.AIR.createBlockData());
             // Calculate ticks until replacement
-            long fadeTicks = (int) (Math.random() * fadeMaximumTicks);
+            long fadeTicks = this.fadeDelayTicks;
+            fadeTicks += (int) (Math.random() * maximumFadeDurationTicks);
             fadeTicks += Settings.ExtraFadeTimePerBlock.getOrDefault(data.getMaterial(), 0);
             // Deffer replacement until time delay elapses
             accumulator = accumulator.andThen(new DeferredEffect(fadeTicks, () -> WorldManager.INSTANCE.submit(new FadeTask(data, replacementData, world, location))));

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -55,10 +55,14 @@ public class WreckTask implements Supplier<Effect> {
             .map(slice -> ForkJoinTask.adapt(() -> partialUpdate(slice)))
             .toList();
 
-        return ForkJoinTask.invokeAll(updates).stream().map(ForkJoinTask::join).reduce(Effect.NONE, Effect::andThen);
+        return ForkJoinTask
+            .invokeAll(updates)
+            .stream()
+            .map(ForkJoinTask::join)
+            .reduce(Effect.NONE, Effect::andThen);
     }
 
-    public Effect partialUpdate(HitBox slice){
+    private @NotNull Effect partialUpdate(@NotNull HitBox slice){
         Effect accumulator = Effect.NONE;
         for (MovecraftLocation location : slice){
             // Get the existing data

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -41,7 +41,7 @@ public class WreckTask implements Supplier<Effect> {
         var updates = hitBox
             .asSet()
             .stream()
-            .collect(Collectors.groupingBy(location -> location.scalarMod(16).hadamardProduct(1,0,1), CollectorUtils.toHitBox()))
+            .collect(Collectors.groupingBy(location -> location.scalarDivide(16).hadamardProduct(1,0,1), CollectorUtils.toHitBox()))
             .values()
             .stream()
             .map(slice -> ForkJoinTask.adapt(() -> partialUpdate(slice)))
@@ -65,7 +65,7 @@ public class WreckTask implements Supplier<Effect> {
             long fadeTicks = (int) (Math.random() * fadeMaximumTicks);
             fadeTicks += Settings.ExtraFadeTimePerBlock.getOrDefault(data.getMaterial(), 0);
             // Deffer replacement until time delay elapses
-            accumulator.andThen(new DeferredEffect(fadeTicks, () -> WorldManager.INSTANCE.submit(new FadeTask(data, replacementData, world, location))));
+            accumulator = accumulator.andThen(new DeferredEffect(fadeTicks, () -> WorldManager.INSTANCE.submit(new FadeTask(data, replacementData, world, location))));
         }
 
         // TODO: Determine if we need to reduce the spread of deferred effects due to runnable overhead

--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/fading/WreckTask.java
@@ -1,6 +1,5 @@
 package net.countercraft.movecraft.features.fading;
 
-import io.papermc.paper.util.Tick;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.processing.MovecraftWorld;
@@ -29,7 +28,9 @@ public class WreckTask implements Supplier<Effect> {
         this.phaseBlocks = Objects.requireNonNull(phaseBlocks);
         this.world = Objects.requireNonNull(world);
 
-        int ticks = Tick.tick().fromDuration(Duration.ofSeconds(Settings.FadeWrecksAfter));
+        // TODO: figure out when Tick class got added
+//        int ticks = Tick.tick().fromDuration(Duration.ofSeconds(Settings.FadeWrecksAfter));
+        int ticks = Settings.FadeWrecksAfter * 20;
         this.fadeMaximumTicks = (int) (ticks / (Settings.FadePercentageOfWreckPerCycle / 100.0));
     }
 

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/DeferredEffect.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/DeferredEffect.java
@@ -1,0 +1,36 @@
+package net.countercraft.movecraft.processing.effects;
+
+import net.countercraft.movecraft.Movecraft;
+import net.countercraft.movecraft.processing.WorldManager;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * A wrapper effect that allows delaying the execution of a provided effect by a number of ticks.
+ */
+public class DeferredEffect implements Effect {
+    private final long delayTicks;
+    private final @NotNull Effect effect;
+
+    public DeferredEffect(long delayTicks, @NotNull Effect effect){
+        this.delayTicks = delayTicks;
+        this.effect = Objects.requireNonNull(effect);
+    }
+    
+    @Override
+    public void run() {
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                WorldManager.INSTANCE.submit(() -> effect);
+            }
+        }.runTaskLaterAsynchronously(Movecraft.getInstance(), delayTicks);
+    }
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+}

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/SetBlockEffect.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/SetBlockEffect.java
@@ -1,16 +1,31 @@
 package net.countercraft.movecraft.processing.effects;
 
 import net.countercraft.movecraft.MovecraftLocation;
-import org.bukkit.Material;
+import net.countercraft.movecraft.mapUpdater.update.BlockCreateCommand;
+import net.countercraft.movecraft.processing.MovecraftWorld;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
 
 public final class SetBlockEffect implements Effect {
-    public SetBlockEffect(World world, MovecraftLocation location, Material material){
+    private final @NotNull MovecraftWorld world;
+    private final @NotNull MovecraftLocation location;
+    private final @NotNull BlockData data;
 
+    public SetBlockEffect(@NotNull MovecraftWorld world, @NotNull MovecraftLocation location, @NotNull BlockData data){
+        this.world = world;
+        this.location = location;
+        this.data = data;
     }
 
     @Override
     public void run() {
-
+        World bukkitWorld = Bukkit.getWorld(world.getWorldUUID());
+        if(bukkitWorld == null) {
+            return;
+        }
+        // TODO: Reverse indirection
+        new BlockCreateCommand(bukkitWorld, location, data).doUpdate();
     }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/SetBlockEffect.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/SetBlockEffect.java
@@ -8,6 +8,9 @@ import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Sets a block based on the provided data.
+ */
 public final class SetBlockEffect implements Effect {
     private final @NotNull MovecraftWorld world;
     private final @NotNull MovecraftLocation location;

--- a/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/SetBlockEffect.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/processing/effects/SetBlockEffect.java
@@ -8,6 +8,8 @@ import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * Sets a block based on the provided data.
  */
@@ -24,10 +26,10 @@ public final class SetBlockEffect implements Effect {
 
     @Override
     public void run() {
-        World bukkitWorld = Bukkit.getWorld(world.getWorldUUID());
-        if(bukkitWorld == null) {
-            return;
-        }
+        World bukkitWorld = Objects.requireNonNull(
+            Bukkit.getWorld(world.getWorldUUID()),
+            "Failed to access base World from MovecraftWorld");
+
         // TODO: Reverse indirection
         new BlockCreateCommand(bukkitWorld, location, data).doUpdate();
     }

--- a/api/src/main/java/net/countercraft/movecraft/MovecraftLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/MovecraftLocation.java
@@ -87,6 +87,14 @@ final public class MovecraftLocation implements Comparable<MovecraftLocation>{
         return new MovecraftLocation(getX() - l.getX(), getY() - l.getY(), getZ() - l.getZ());
     }
 
+    public MovecraftLocation hadamardProduct(int x, int y, int z){
+        return new MovecraftLocation(this.x*x, this.y*y, this.z*z);
+    }
+
+    public MovecraftLocation hadamardProduct(MovecraftLocation location){
+        return hadamardProduct(location.x, location.y, location.z);
+    }
+
     public MovecraftLocation scalarMultiply(int multiplier){
         return new MovecraftLocation(x * multiplier, y * multiplier, z * multiplier);
     }

--- a/api/src/main/java/net/countercraft/movecraft/MovecraftLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/MovecraftLocation.java
@@ -87,6 +87,18 @@ final public class MovecraftLocation implements Comparable<MovecraftLocation>{
         return new MovecraftLocation(getX() - l.getX(), getY() - l.getY(), getZ() - l.getZ());
     }
 
+    public MovecraftLocation scalarMultiply(int multiplier){
+        return new MovecraftLocation(x * multiplier, y * multiplier, z * multiplier);
+    }
+
+    public MovecraftLocation scalarDivide(int divisor){
+        return new MovecraftLocation(x / divisor, y / divisor, z/divisor);
+    }
+
+    public MovecraftLocation scalarMod(int modulus){
+        return new MovecraftLocation(x % modulus, y & modulus, z % modulus);
+    }
+
     /**
      *
      * Gives the euclidean distance between this MovecraftLocation and another MovecraftLocation

--- a/api/src/main/java/net/countercraft/movecraft/processing/WorldManager.java
+++ b/api/src/main/java/net/countercraft/movecraft/processing/WorldManager.java
@@ -4,6 +4,7 @@ import net.countercraft.movecraft.processing.effects.Effect;
 import net.countercraft.movecraft.util.CompletableFutureTask;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ public final class WorldManager implements Executor {
     };
 
     private final ConcurrentLinkedQueue<Effect> worldChanges = new ConcurrentLinkedQueue<>();
-    private final ConcurrentLinkedQueue<Supplier<Effect>> tasks = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<Supplier<@Nullable Effect>> tasks = new ConcurrentLinkedQueue<>();
     private final BlockingQueue<Runnable> currentTasks = new LinkedBlockingQueue<>();
     private volatile boolean running = false;
 
@@ -122,7 +123,7 @@ public final class WorldManager implements Executor {
         });
     }
 
-    public void submit(Supplier<Effect> task){
+    public void submit(Supplier<@Nullable Effect> task){
         tasks.add(task);
     }
 

--- a/api/src/main/java/net/countercraft/movecraft/processing/effects/Effect.java
+++ b/api/src/main/java/net/countercraft/movecraft/processing/effects/Effect.java
@@ -1,7 +1,11 @@
 package net.countercraft.movecraft.processing.effects;
 
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @FunctionalInterface
 public interface Effect {
@@ -32,12 +36,44 @@ public interface Effect {
     }
 
     default @NotNull Effect andThen(@Nullable Effect chain){
-        if(chain == null){
+        return new AndEffect(this, chain);
+    }
+
+    class AndEffect implements Effect {
+        private final List<Effect> effects = new ArrayList<>();
+
+        public AndEffect(Effect... effects){
+            for (Effect effect : effects) {
+                andThen(effect);
+            }
+        }
+
+        @Override
+        public void run() {
+            effects.forEach(Effect::run);
+        }
+
+        @Override
+        public @NotNull Effect andThen(@Nullable Effect chain) {
+            if(this == chain){
+                // copy if chaining to self to prevent concurrent modification
+                effects.addAll(effects.stream().toList());
+
+                return this;
+            } else if(chain instanceof AndEffect andChain){
+                // Merge other AndChain instances
+                effects.addAll(andChain.effects);
+
+                return this;
+            } else if(chain == NONE || chain == null){
+                // Skip NONE
+                return this;
+            }
+
+            // Otherwise add to current chain
+            effects.add(chain);
+
             return this;
         }
-        return () -> {
-            this.run();
-            chain.run();
-        };
     }
 }

--- a/api/src/main/java/net/countercraft/movecraft/processing/effects/Effect.java
+++ b/api/src/main/java/net/countercraft/movecraft/processing/effects/Effect.java
@@ -5,6 +5,18 @@ import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
 public interface Effect {
+    Effect NONE = new Effect() {
+        @Override
+        public void run() {
+            // No-op
+        }
+
+        @Override
+        public boolean isAsync() {
+            return true;
+        }
+    };
+
     void run();
 
     default boolean isAsync(){

--- a/api/src/main/java/net/countercraft/movecraft/processing/effects/Effect.java
+++ b/api/src/main/java/net/countercraft/movecraft/processing/effects/Effect.java
@@ -5,6 +5,9 @@ import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
 public interface Effect {
+    /**
+     * A no-op effect for use in systems where a non-null effect is needed
+     */
     Effect NONE = new Effect() {
         @Override
         public void run() {
@@ -15,6 +18,11 @@ public interface Effect {
         public boolean isAsync() {
             return true;
         }
+
+        @Override
+        public @NotNull Effect andThen(@Nullable Effect chain){
+            return chain == null ? this : chain;
+        }
     };
 
     void run();
@@ -23,8 +31,7 @@ public interface Effect {
         return false;
     }
 
-    default @NotNull
-    Effect andThen(@Nullable Effect chain){
+    default @NotNull Effect andThen(@Nullable Effect chain){
         if(chain == null){
             return this;
         }

--- a/api/src/main/java/net/countercraft/movecraft/util/CollectorUtils.java
+++ b/api/src/main/java/net/countercraft/movecraft/util/CollectorUtils.java
@@ -6,6 +6,10 @@ import net.countercraft.movecraft.util.hitboxes.BitmapHitBox;
 import java.util.stream.Collector;
 
 public class CollectorUtils {
+    /**
+     * Provides a collector for reducing streams of MovecraftLocations to HitBox instances
+     * @return A HitBox containing all collected MovecraftLocations
+     */
     public static Collector<MovecraftLocation, ?, BitmapHitBox> toHitBox(){
         return Collector.of(BitmapHitBox::new, BitmapHitBox::add, BitmapHitBox::union, t->t);
     }

--- a/api/src/main/java/net/countercraft/movecraft/util/CollectorUtils.java
+++ b/api/src/main/java/net/countercraft/movecraft/util/CollectorUtils.java
@@ -1,0 +1,12 @@
+package net.countercraft.movecraft.util;
+
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.util.hitboxes.BitmapHitBox;
+
+import java.util.stream.Collector;
+
+public class CollectorUtils {
+    public static Collector<MovecraftLocation, ?, BitmapHitBox> toHitBox(){
+        return Collector.of(BitmapHitBox::new, BitmapHitBox::add, BitmapHitBox::union, t->t);
+    }
+}

--- a/v1_18/src/main/java/net/countercraft/movecraft/support/v1_18/IAsyncChunk.java
+++ b/v1_18/src/main/java/net/countercraft/movecraft/support/v1_18/IAsyncChunk.java
@@ -7,6 +7,7 @@ import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.support.AsyncChunk;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
@@ -26,8 +27,11 @@ public class IAsyncChunk extends AsyncChunk<CraftChunk> {
         }
     });
 
+    private final ChunkAccess handle;
+
     public IAsyncChunk(@NotNull Chunk chunk) {
         super(chunk);
+        handle = this.chunk.getHandle();
     }
 
     @NotNull
@@ -51,7 +55,7 @@ public class IAsyncChunk extends AsyncChunk<CraftChunk> {
     @Override
     @NotNull
     public BlockData getData(@NotNull MovecraftLocation location){
-        return CraftBlockData.fromData(chunk.getHandle().getBlockState(new BlockPos(location.getX(), location.getY(), location.getZ())));
+        return CraftBlockData.fromData(handle.getBlockState(new BlockPos(location.getX(), location.getY(), location.getZ())));
     }
 
 }


### PR DESCRIPTION
This PR brings back #686 with tested performance fixes by removing the possible deadlock in the 1.18.2 worldhandler.