### PR TITLE
[Feature] Sign rework api (part 1 of 2 for sign rework PR)

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -59,6 +59,7 @@ public class Movecraft extends JavaPlugin {
     private SmoothTeleport smoothTeleport;
     private AsyncManager asyncManager;
     private WreckManager wreckManager;
+    private AbstractSignListener abstractSignListener;
 
     public static synchronized Movecraft getInstance() {
         return instance;
@@ -131,6 +132,13 @@ public class Movecraft extends JavaPlugin {
                     smoothTeleport = new BukkitTeleport(); // Fall back to bukkit teleportation
                     getLogger().warning("Falling back to bukkit teleportation provider.");
                 }
+            }
+
+            // Create instance of sign listener
+            final Class<?> signListenerClass = Class.forName("net.countercraft.movecraft.compat." + WorldHandler.getPackageName(minecraftVersion) + ".SignListener");
+            if (AbstractSignListener.class.isAssignableFrom(signListenerClass)) {
+                abstractSignListener = (AbstractSignListener) signListenerClass.getConstructor().newInstance();
+                getServer().getPluginManager().registerEvents(abstractSignListener, this);
             }
         }
         catch (final Exception e) {
@@ -339,5 +347,9 @@ public class Movecraft extends JavaPlugin {
 
     public @NotNull WreckManager getWreckManager(){
         return wreckManager;
+    }
+
+    public AbstractSignListener getAbstractSignListener() {
+        return abstractSignListener;
     }
 }

--- a/api/src/main/java/net/countercraft/movecraft/MovecraftRotation.java
+++ b/api/src/main/java/net/countercraft/movecraft/MovecraftRotation.java
@@ -18,5 +18,18 @@
 package net.countercraft.movecraft;
 
 public enum MovecraftRotation {
-    CLOCKWISE, NONE, ANTICLOCKWISE
+    CLOCKWISE, NONE, ANTICLOCKWISE;
+	
+	public static MovecraftRotation fromAction(Action clickType) {
+        switch (clickType) {
+            case LEFT_CLICK_AIR:
+            case LEFT_CLICK_BLOCK:
+                return ANTICLOCKWISE;
+            case RIGHT_CLICK_AIR:
+            case RIGHT_CLICK_BLOCK:
+                return CLOCKWISE;
+            default:
+                return NONE;
+        }
+    }
 }

--- a/api/src/main/java/net/countercraft/movecraft/events/SignTranslateEvent.java
+++ b/api/src/main/java/net/countercraft/movecraft/events/SignTranslateEvent.java
@@ -2,46 +2,89 @@ package net.countercraft.movecraft.events;
 
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.sign.AbstractSignListener;
+import net.kyori.adventure.text.Component;
+import org.bukkit.block.BlockFace;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+// TODO: Rewrite to use the adventure API
 public class SignTranslateEvent extends CraftEvent{
     private static final HandlerList HANDLERS = new HandlerList();
     @NotNull private final List<MovecraftLocation> locations;
-    @NotNull private final String[] lines;
+    @NotNull private final AbstractSignListener.SignWrapper backing;
     private boolean updated = false;
 
+    @Deprecated(forRemoval = true)
     public SignTranslateEvent(@NotNull Craft craft, @NotNull String[] lines, @NotNull List<MovecraftLocation> locations) throws IndexOutOfBoundsException{
         super(craft);
         this.locations = locations;
-        if(lines.length!=4)
-            throw new IndexOutOfBoundsException();
-        this.lines=lines;
+        List<Component> components = new ArrayList<>();
+        for (String s : lines) {
+            components.add(Component.text(s));
+        }
+        this.backing = new AbstractSignListener.SignWrapper(null, components::get, components, components::set, BlockFace.SELF);
+    }
+
+    public SignTranslateEvent(@NotNull Craft craft, @NotNull AbstractSignListener.SignWrapper backing, @NotNull List<MovecraftLocation> locations) throws IndexOutOfBoundsException{
+        super(craft);
+        this.locations = locations;
+        this.backing = backing;
     }
 
     @NotNull
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public String[] getLines() {
+        // TODO: Why does this set it to updated? This is just reading...
         this.updated = true;
-        return lines;
+        return backing.rawLines();
     }
 
+    @Deprecated(forRemoval = true)
     public String getLine(int index) throws IndexOutOfBoundsException{
         if(index > 3 || index < 0)
             throw new IndexOutOfBoundsException();
-        return lines[index];
+        return backing.getRaw(index);
     }
 
+    @Deprecated(forRemoval = true)
     public void setLine(int index, String line){
         if(index > 3 || index < 0)
             throw new IndexOutOfBoundsException();
         this.updated = true;
-        lines[index]=line;
+        backing.line(index, Component.text(line));
     }
 
+    public Component line(int index) {
+        return backing.line(index);
+    }
+
+    public void line(int index, Component component) {
+        this.updated = true;
+        backing.line(index, component);
+    }
+
+    public String getRaw(int index) {
+        return backing.getRaw(index);
+    }
+
+    public String[] rawLines() {
+        return backing.rawLines();
+    }
+
+    public BlockFace facing() {
+        return backing.facing();
+    }
+
+    public List<Component> lines() {
+        return backing.lines();
+    }
+
+    // Bukkit crap
     @Override
     public HandlerList getHandlers() {
         return HANDLERS;

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftPilotSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftPilotSign.java
@@ -1,0 +1,17 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.craft.type.CraftType;
+
+/*
+ * Base implementation for all craft pilot signs, does nothing but has the relevant CraftType instance backed
+ */
+public abstract class AbstractCraftPilotSign extends AbstractMovecraftSign {
+
+    protected final CraftType craftType;
+
+    public AbstractCraftPilotSign(final CraftType craftType) {
+        super();
+        this.craftType = craftType;
+    }
+
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractCraftSign.java
@@ -1,0 +1,123 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.PilotedCraft;
+import net.countercraft.movecraft.craft.PlayerCraft;
+import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/*
+ * Extension of @AbstractMovecraftSign
+ * The difference is, that for this sign to work, it must exist on a craft instance
+ *
+ * Also this will react to the SignTranslate event
+ */
+public abstract class AbstractCraftSign extends AbstractMovecraftSign {
+
+    // Helper method for the listener
+    public static Optional<AbstractCraftSign> tryGetCraftSign(final Component ident) {
+        if (ident == null) {
+            return Optional.empty();
+        }
+        final String identStr = PlainTextComponentSerializer.plainText().serialize(ident);
+        return tryGetCraftSign(identStr);
+    }
+
+    public static Optional<AbstractCraftSign> tryGetCraftSign(final String ident) {
+        Optional<AbstractMovecraftSign> tmp = AbstractCraftSign.tryGet(ident);
+        if (tmp.isPresent() && tmp.get() instanceof AbstractCraftSign acs) {
+            return Optional.of(acs);
+        }
+        return Optional.empty();
+    }
+
+    protected final boolean ignoreCraftIsBusy;
+
+    public AbstractCraftSign(boolean ignoreCraftIsBusy) {
+        this(null, ignoreCraftIsBusy);
+    }
+
+    public AbstractCraftSign(final String permission, boolean ignoreCraftIsBusy) {
+        super(permission);
+        this.ignoreCraftIsBusy = ignoreCraftIsBusy;
+    }
+
+    // Similar to the super class variant
+    // In addition a check for a existing craft is being made
+    // If the craft is a player craft that is currently processing and ignoreCraftIsBusy is set to false, this will quit early and call onCraftIsBusy()
+    // If no craft is found, onCraftNotFound() is called
+    // Return true to cancel the event
+    @Override
+    public boolean processSignClick(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        if (!this.isSignValid(clickType, sign, player)) {
+            return false;
+        }
+        if (!this.canPlayerUseSign(clickType, sign, player)) {
+            return false;
+        }
+        Craft craft = this.getCraft(sign);
+        if (craft == null) {
+            this.onCraftNotFound(player, sign);
+            return false;
+        }
+
+        if (craft instanceof PlayerCraft pc) {
+            if (!pc.isNotProcessing() && !this.ignoreCraftIsBusy) {
+                this.onCraftIsBusy(player, craft);
+                return false;
+            }
+        }
+
+        return internalProcessSign(clickType, sign, player, craft);
+    }
+
+    // Implementation of the standard method.
+    // The craft instance is required here and it's existance is being confirmed in processSignClick() in beforehand
+    // After that, canPlayerUseSignOn() is being called. If that is successful, the result of internalProcessSignWithCraft() is returned
+    @Override
+    protected boolean internalProcessSign(Action clickType, AbstractSignListener.SignWrapper sign, Player player, @Nullable Craft craft) {
+        if (craft == null) {
+            throw new IllegalStateException("Somehow craft is not set here. It should always be present here!");
+        }
+        if (this.canPlayerUseSignOn(player, craft)) {
+            return this.internalProcessSignWithCraft(clickType, sign, craft, player);
+        }
+        return false;
+    }
+
+    // Called when the craft is a player craft and is processing and ignoreCraftIsBusy is set to false
+    protected abstract void onCraftIsBusy(Player player, Craft craft);
+
+    // Validation method, intended to indicate if a player is allowed to execute a sign action on a mounted craft
+    // By default, this returns wether or not the player is the pilot of the craft
+    protected boolean canPlayerUseSignOn(Player player, @Nullable Craft craft) {
+        if (craft instanceof PilotedCraft pc) {
+            return pc.getPilot() == player;
+        }
+        return true;
+    }
+
+    // Called when there is no craft instance for this sign
+    protected abstract void onCraftNotFound(Player player, AbstractSignListener.SignWrapper sign);
+
+    // By default we don't react to CraftDetectEvent here
+    public void onCraftDetect(CraftDetectEvent event, AbstractSignListener.SignWrapper sign) {
+        // Do nothing by default
+    }
+
+    public void onSignMovedByCraft(SignTranslateEvent event) {
+        // Do nothing by default
+    }
+
+    // Gets called by internalProcessSign if a craft is found
+    // Always override this as the validation has been made already when this is being called
+    protected abstract boolean internalProcessSignWithCraft(Action clickType, AbstractSignListener.SignWrapper sign, Craft craft, Player player);
+
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractCruiseSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractCruiseSign.java
@@ -1,0 +1,169 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.CruiseDirection;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.PilotedCraft;
+import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.SignChangeEvent;
+import org.jetbrains.annotations.Nullable;
+
+/*
+ * Base class for all cruise signs
+ *
+ * Has the relevant logic for the "state" suffix (on / off) as well as calling the relevant methods and setting the craft to cruising
+ *
+ */
+public abstract class AbstractCruiseSign extends AbstractCraftSign {
+
+    private final String suffixOn;
+    private final String suffixOff;
+    private final String ident = AbstractMovecraftSign.findIdent(this);
+
+    public AbstractCruiseSign(boolean ignoreCraftIsBusy, final String suffixOn, final String suffixOff) {
+        this(null, ignoreCraftIsBusy, suffixOn, suffixOff);
+    }
+
+    public AbstractCruiseSign(final String permission, boolean ignoreCraftIsBusy, final String suffixOn, final String suffixOff) {
+        super(permission, ignoreCraftIsBusy);
+        this.suffixOn = suffixOn;
+        this.suffixOff = suffixOff;
+    }
+
+    // Checks if the header is empty, if yes, it quits early (unnecessary actually as if it was empty this would never be called)
+    // Afterwards the header is validated, if it's splitted variant doesn't have exactly 2 entries it is invalid
+    // Finally, the "state" (second part of the header) isn't matching suffixOn or suffixOff, it is invalid
+    @Override
+    protected boolean isSignValid(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        if (PlainTextComponentSerializer.plainText().serialize(sign.line(0)).isBlank()) {
+            return false;
+        }
+        String[] headerSplit = getSplitHeader(sign);
+        if (headerSplit.length != 2) {
+            return false;
+        }
+        String suffix = headerSplit[1];
+        return suffix.equalsIgnoreCase(this.suffixOff) || suffix.equalsIgnoreCase(this.suffixOn);
+    }
+
+    // Returns the raw header, which should consist of the ident and either the suffixOn or suffixOff value
+    // Returns null if the header is blank
+    @Nullable
+    protected static String[] getSplitHeader(final AbstractSignListener.SignWrapper sign) {
+        String header = PlainTextComponentSerializer.plainText().serialize(sign.line(0));
+        if (header.isBlank()) {
+            return null;
+        }
+        return header.split(":");
+    }
+
+    // If the suffix matches the suffixOn field it will returnt true
+    // calls getSplitHeader() to retrieve the raw header string
+    protected boolean isOnOrOff(AbstractSignListener.SignWrapper sign) {
+        String[] headerSplit = getSplitHeader(sign);
+        if (headerSplit == null || headerSplit.length != 2) {
+            return false;
+        }
+        String suffix = headerSplit[1];
+        return suffix.equalsIgnoreCase(this.suffixOn);
+    }
+
+    // By default, cancel the event if the processing was successful, or the invoker was not sneaking => Allows breaking signs while sneaking
+    @Override
+    public boolean shouldCancelEvent(boolean processingSuccessful, @Nullable Action type, boolean sneaking) {
+        return processingSuccessful || !sneaking;
+    }
+
+    // Hook to do stuff that run after stopping to cruise
+    protected void onAfterStoppingCruise(Craft craft, AbstractSignListener.SignWrapper signWrapper, Player player) {
+
+    }
+
+    // Hook to do stuff that run after starting to cruise
+    protected void onAfterStartingCruise(Craft craft, AbstractSignListener.SignWrapper signWrapper, Player player) {
+
+    }
+
+    // Actual processing, determines wether the sign will switch to on or off
+    // If it will be on, the CruiseDirection is retrieved and then setCraftCruising() is called
+    // Otherwise, the craft will stop cruising
+    // Then the sign is updated and the block resetted
+    // Finally, the relevant hooks are called
+    // This always returns true
+    @Override
+    protected boolean internalProcessSignWithCraft(Action clickType, AbstractSignListener.SignWrapper sign, Craft craft, Player player) {
+        boolean isOn = this.isOnOrOff(sign);
+        boolean willBeOn = !isOn;
+        if (willBeOn) {
+            CruiseDirection direction = this.getCruiseDirection(sign);
+            this.setCraftCruising(player, direction, craft);
+        } else {
+           craft.setCruising(false);
+        }
+
+        // Update sign
+        sign.line(0, buildHeader(willBeOn));
+        sign.block().update(true);
+        // TODO: What to replace this with?
+        craft.resetSigns(sign.block());
+
+        if (willBeOn) {
+            this.onAfterStartingCruise(craft, sign, player);
+        } else {
+            this.onAfterStoppingCruise(craft, sign, player);
+        }
+
+        return true;
+    }
+
+    // On sign placement, if the entered header is the same as our ident, it will append the off-suffix automatically
+    @Override
+    public boolean processSignChange(SignChangeEvent event, AbstractSignListener.SignWrapper sign) {
+        String header = sign.getRaw(0).trim();
+        if (header.equalsIgnoreCase(this.ident)) {
+            sign.line(0, buildHeaderOff());
+        }
+        return true;
+    }
+
+    // On craft detection, we set all the headers to the "off" header
+    @Override
+    public void onCraftDetect(CraftDetectEvent event, AbstractSignListener.SignWrapper sign) {
+        Player p = null;
+        if (event.getCraft() instanceof PilotedCraft pc) {
+            p = pc.getPilot();
+        }
+
+        if (this.isSignValid(Action.PHYSICAL, sign, p)) {
+            sign.line(0, buildHeader(false));
+        } else {
+            // TODO: Error? React in any way?
+            sign.line(0, buildHeader(false));
+        }
+    }
+
+    // Helper method to build the headline for on or off state
+    protected Component buildHeader(boolean on) {
+        return on ? buildHeaderOn() : buildHeaderOff();
+    }
+
+    protected Component buildHeaderOn() {
+        return Component.text(this.ident).append(Component.text(": ")).append(Component.text(this.suffixOn, Style.style(TextColor.color(0, 255, 0))));
+    }
+
+    protected Component buildHeaderOff() {
+        return Component.text(this.ident).append(Component.text(": ")).append(Component.text(this.suffixOff, Style.style(TextColor.color(255, 0, 0))));
+    }
+
+    // Should call the craft's relevant methods to start cruising
+    protected abstract void setCraftCruising(Player player, CruiseDirection direction, Craft craft);
+
+    // TODO: Rework cruise direction to vectors => Vector defines the skip distance and the direction
+    // Returns the direction in which the craft should cruise
+    protected abstract CruiseDirection getCruiseDirection(AbstractSignListener.SignWrapper sign);
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractInformationSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractInformationSign.java
@@ -1,0 +1,165 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.SignChangeEvent;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class AbstractInformationSign extends AbstractCraftSign {
+
+    public static final Component EMPTY = Component.text("");
+
+    protected static final Style STYLE_COLOR_GREEN = Style.style(TextColor.color(0, 255, 0));
+    protected static final Style STYLE_COLOR_YELLOW = Style.style(TextColor.color(255, 255, 0));
+    protected static final Style STYLE_COLOR_RED = Style.style(TextColor.color(255, 0, 0));
+    protected static final Style STYLE_COLOR_WHITE = Style.style(TextColor.color(255, 255, 255));
+
+    public enum REFRESH_CAUSE {
+        SIGN_CREATION,
+        CRAFT_DETECT,
+        SIGN_MOVED_BY_CRAFT,
+        SIGN_CLICK
+    }
+
+    public AbstractInformationSign() {
+        // Info signs only display things, that should not require permissions, also it doesn't matter if the craft is busy or not
+        super(null, true);
+    }
+
+    @Override
+    protected boolean canPlayerUseSignOn(Player player, Craft craft) {
+        // Permcheck related, no perms required, return true
+        return true;
+    }
+
+    @Override
+    public void onCraftDetect(CraftDetectEvent event, AbstractSignListener.SignWrapper sign) {
+        // TODO: Check if the craft supports this sign? If no, cancel
+        super.onCraftDetect(event, sign);
+        this.refreshSign(event.getCraft(), sign, true, REFRESH_CAUSE.CRAFT_DETECT);
+    }
+
+    @Override
+    public void onSignMovedByCraft(SignTranslateEvent event) {
+        super.onSignMovedByCraft(event);
+        final Craft craft = event.getCraft();
+        AbstractSignListener.SignWrapper wrapperTmp = new AbstractSignListener.SignWrapper(null, event::line, event.lines(), event::line, BlockFace.SELF);
+        if (this.refreshSign(craft, wrapperTmp, false, REFRESH_CAUSE.SIGN_MOVED_BY_CRAFT)) {
+            for (MovecraftLocation movecraftLocation : event.getLocations()) {
+                Block block = movecraftLocation.toBukkit(craft.getWorld()).getBlock();
+                if (block instanceof Sign sign) {
+                    AbstractSignListener.SignWrapper wrapperTmpTmp = new AbstractSignListener.SignWrapper(sign, event::line, event.lines(), event::line, event.facing());
+                    this.sendUpdatePacket(craft, wrapperTmpTmp, REFRESH_CAUSE.SIGN_MOVED_BY_CRAFT);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onCraftNotFound(Player player, AbstractSignListener.SignWrapper sign) {
+        // Nothing to do
+    }
+
+    @Override
+    protected boolean isSignValid(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldCancelEvent(boolean processingSuccessful, @Nullable Action type, boolean sneaking) {
+        if (processingSuccessful) {
+            return true;
+        }
+        return !sneaking;
+    }
+
+    @Override
+    protected boolean internalProcessSignWithCraft(Action clickType, AbstractSignListener.SignWrapper sign, Craft craft, Player player) {
+        if (this.refreshSign(craft, sign, false, REFRESH_CAUSE.SIGN_CLICK)) {
+            this.sendUpdatePacket(craft, sign, REFRESH_CAUSE.SIGN_CLICK);
+        }
+        return true;
+    }
+
+    // Called whenever the info needs to be refreshed
+    // That happens on CraftDetect, sign right click (new), Sign Translate
+    // The new and old values are gathered here and compared
+    // If nothing has changed, no update happens
+    // If something has changed, performUpdate() and sendUpdatePacket() are called
+    // Returns wether or not something has changed
+    protected boolean refreshSign(@Nullable Craft craft, AbstractSignListener.SignWrapper sign, boolean fillDefault, REFRESH_CAUSE refreshCause) {
+        boolean changedSome = false;
+        Component[] updatePayload = new Component[sign.lines().size()];
+        for(int i = 1; i < sign.lines().size(); i++) {
+            Component oldComponent = sign.line(i);
+            Component potentiallyNew;
+            if (craft == null || fillDefault) {
+                potentiallyNew = this.getDefaultString(i, oldComponent);
+            } else {
+                 potentiallyNew = this.getUpdateString(i, oldComponent, craft);
+            }
+            if (potentiallyNew != null && !potentiallyNew.equals(oldComponent)) {
+                String oldValue = PlainTextComponentSerializer.plainText().serialize(oldComponent);
+                String newValue = PlainTextComponentSerializer.plainText().serialize(potentiallyNew);
+                if (!oldValue.equals(newValue)) {
+                    changedSome = true;
+                    updatePayload[i] = potentiallyNew;
+                }
+            }
+        }
+        if (changedSome) {
+            this.performUpdate(updatePayload, sign, refreshCause);
+        }
+        return changedSome;
+    }
+
+    @Override
+    public boolean processSignChange(SignChangeEvent event, AbstractSignListener.SignWrapper sign) {
+        if (this.refreshSign(null, sign, true, REFRESH_CAUSE.SIGN_CREATION)) {
+            this.sendUpdatePacket(null, sign, REFRESH_CAUSE.SIGN_CREATION);
+        }
+        return true;
+    }
+
+    /*
+    Data to set on the sign. Return null if no update should happen!
+    Attention: A update will only be performed, if the new and old component are different!
+     */
+    @Nullable
+    protected abstract Component getUpdateString(int lineIndex, Component oldData, Craft craft);
+
+    // Returns the default value for this info sign per line
+    // Used on CraftDetect and on sign change
+    @Nullable
+    protected abstract Component getDefaultString(int lineIndex, Component oldComponent);
+
+    /*
+     * @param newComponents: Array of nullable values. The index represents the index on the sign. Only contains the updated components
+     *
+     * Only gets called if at least one line has changed
+     */
+    protected abstract void performUpdate(Component[] newComponents, AbstractSignListener.SignWrapper sign, REFRESH_CAUSE refreshCause);
+
+    /*
+    Gets called after performUpdate has been called
+     */
+    protected void sendUpdatePacket(Craft craft, AbstractSignListener.SignWrapper sign, REFRESH_CAUSE refreshCause) {
+        if (sign.block() == null) {
+            return;
+        }
+        for (Player player : sign.block().getLocation().getNearbyPlayers(16)) {
+            player.sendSignChange(sign.block().getLocation(), sign.lines());
+        }
+    }
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractMovecraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractMovecraftSign.java
@@ -1,0 +1,160 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.type.CraftType;
+import net.countercraft.movecraft.util.MathUtils;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.SignChangeEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.function.Function;
+
+// DONE: In 1.21 signs can have multiple sides! This requires us to pass the clicked side through or well the relevant lines and the set method for the clicked side => Resolved using the SignWrapper
+/*
+ * Base class for all signs
+ *
+ * A instance of a sign needs to be registered using the register function.
+ * Signs react to the following events:
+ *  - SignChangeEvent
+ *  - PlayerInteractEvent, if the clicked block is a sign
+ *  - CraftDetectEvent
+ *  - SignTranslateEvent (if the sign is a subclass of AbstractCraftSign)
+ *
+ *  Whenenver one of those events are cought by the AbstractSignListener instance, it is attempted to retrieve the relevant AbstractMovecraftSign instance.
+ *  For that, the first line of the sign's clicked side is extracted and formatting removed. If it matches the format "foo: bar", only "foo:" will be used.
+ *  With that ident, the sign is attempted to be retrieved vy tryGet(). If that returns something, the object's relevant method is called.
+ */
+public abstract class AbstractMovecraftSign {
+
+    private static final Map<String, AbstractMovecraftSign> SIGNS = Collections.synchronizedMap(new HashMap<>());
+
+    public static boolean hasBeenRegistered(final String ident) {
+        return SIGNS.containsKey(ident);
+    }
+
+    // Special case for pilot signs, they are registered via the crafttypes name
+    public static void registerCraftPilotSigns(Set<CraftType> loadedTypes, Function<CraftType, AbstractCraftPilotSign> signFactory) {
+        SIGNS.entrySet().removeIf(entry ->  entry.getValue() instanceof AbstractCraftPilotSign);
+        // Now, add all types...
+        for (CraftType type : loadedTypes) {
+            AbstractCraftPilotSign sign = signFactory.apply(type);
+            register(type.getStringProperty(CraftType.NAME), sign, true);
+        }
+    }
+
+    public static Optional<AbstractMovecraftSign> tryGet(final Component ident) {
+        if (ident == null) {
+            return Optional.empty();
+        }
+        final String identStr = PlainTextComponentSerializer.plainText().serialize(ident);
+        return tryGet(identStr);
+    }
+
+    // Attempts to find a AbstractMovecraftSign instance, if something has been registered
+    // If the ident follows the format "foo: bar", only "foo:" is used as ident to search for
+    public static Optional<AbstractMovecraftSign> tryGet(final String ident) {
+        String identToUse = ident.toUpperCase();
+        if (identToUse.contains(":")) {
+            identToUse = identToUse.split(":")[0];
+            // Re-add the : cause things should be registered with : at the end
+            identToUse = identToUse + ":";
+        }
+        return Optional.ofNullable(SIGNS.getOrDefault(identToUse, null));
+    }
+
+    // Registers a sign in all cases
+    public static void register(final String ident, final @Nonnull AbstractMovecraftSign instance) {
+        register(ident, instance, true);
+    }
+
+    // Registers a sign
+    // If @param overrideIfAlreadyRegistered is set to false, it won't be registered if something has elready been registered using that name
+    public static void register(final String ident, final @Nonnull AbstractMovecraftSign instance, boolean overrideIfAlreadyRegistered) {
+        if (overrideIfAlreadyRegistered) {
+            SIGNS.put(ident.toUpperCase(), instance);
+        } else {
+            SIGNS.putIfAbsent(ident.toUpperCase(), instance);
+        }
+    }
+
+    // Optional permission for this sign
+    // Note that this is only checked against in normal processSignClick by default
+    // When using the default constructor, the permission will not be set
+    @Nullable
+    protected final String permissionString;
+
+    public AbstractMovecraftSign() {
+        this(null);
+    }
+
+    public AbstractMovecraftSign(String permissionNode) {
+        this.permissionString = permissionNode;
+    }
+
+    // Utility function to retrieve the ident of a a given sign instance
+    // DO NOT call this for unregistered instances!
+    // It is a good idea to cache the return value of this function cause otherwise a loop over all registered sign instances will be necessary
+    public static String findIdent(AbstractMovecraftSign instance) {
+        if (!SIGNS.containsValue(instance)) {
+            throw new IllegalArgumentException("MovecraftSign instance must be registered!");
+        }
+        for (Map.Entry<String, AbstractMovecraftSign> entry : SIGNS.entrySet()) {
+            if (entry.getValue() == instance) {
+                return entry.getKey();
+            }
+        }
+        throw new IllegalStateException("Somehow didn't find a key for a value that is in the map!");
+    }
+
+    // Called whenever a player clicks the sign
+    // SignWrapper wraps the relevant clicked side of the sign and the sign block itself
+    // If true is returned, the event will be cancelled
+    public boolean processSignClick(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        if (!this.isSignValid(clickType, sign, player)) {
+            return false;
+        }
+        if (!this.canPlayerUseSign(clickType, sign, player)) {
+            return false;
+        }
+
+        return internalProcessSign(clickType, sign, player, getCraft(sign));
+    }
+
+    // Validation method
+    // By default this checks if the player has the set permission
+    protected boolean canPlayerUseSign(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        if (this.permissionString == null || this.permissionString.isBlank()) {
+            return true;
+        }
+        return player.hasPermission(this.permissionString);
+    }
+
+    // Helper method, simply calls the existing methods
+    @Nullable
+    protected Craft getCraft(AbstractSignListener.SignWrapper sign) {
+        return MathUtils.getCraftByPersistentBlockData(sign.block().getLocation());
+    }
+
+    // Used by the event handler to determine if the event should be cancelled
+    // processingSuccessful is the output of processSignClick() or processSignChange()
+    // This is only called for the PlayerInteractEvent and the SignChangeEvent
+    public abstract boolean shouldCancelEvent(boolean processingSuccessful, @Nullable Action type, boolean sneaking);
+
+    // Validation method, called by default in processSignClick
+    // If false is returned, nothing will be processed
+    protected abstract boolean isSignValid(Action clickType, AbstractSignListener.SignWrapper sign, Player player);
+
+    // Called by processSignClick after validation. At this point, isSignValid() and canPlayerUseSign() have been called already
+    // If the sign belongs to a craft, that craft is given in the @param craft argument
+    // Return true, if everything was ok
+    protected abstract boolean internalProcessSign(Action clickType, AbstractSignListener.SignWrapper sign, Player player, @Nullable Craft craft);
+
+    // Called by the event handler when SignChangeEvent is being cought
+    // Return true, if everything was ok
+    public abstract boolean processSignChange(SignChangeEvent event, AbstractSignListener.SignWrapper sign);
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractSignListener.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractSignListener.java
@@ -1,0 +1,211 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.events.CraftDetectEvent;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/*
+ * As soon as 1.18 support is dropped, the adapter system will be dropped too
+ */
+@Deprecated(forRemoval = true)
+public abstract class AbstractSignListener implements Listener {
+
+    public static AbstractSignListener INSTANCE;
+
+    public AbstractSignListener() {
+        INSTANCE = this;
+    }
+
+    /*
+     * As soon as 1.18 support is dropped, the adapter system will be dropped too
+     */
+    @Deprecated(forRemoval = true)
+    public record SignWrapper(
+            @Nullable Sign block,
+            Function<Integer, Component> getLine,
+            List<Component> lines,
+            BiConsumer<Integer, Component> setLine,
+            BlockFace facing
+    ) {
+        public Component line(int index) {
+            if (index >= lines.size() || index < 0) {
+                throw new IndexOutOfBoundsException();
+            }
+            return getLine().apply(index);
+        }
+
+        public void line(int index, Component component) {
+            setLine.accept(index, component);
+        }
+
+        public String getRaw(int index) {
+            return PlainTextComponentSerializer.plainText().serialize(line(index));
+        }
+
+        public String[] rawLines() {
+            String[] result = new String[this.lines.size()];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = this.getRaw(i);
+            }
+            return result;
+        }
+
+        public boolean isEmpty() {
+            for(String s : this.rawLines()) {
+                if (s.trim().isEmpty() || s.trim().isBlank()) {
+                    continue;
+                }
+                else {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof SignWrapper other) {
+                return areSignsEqual(other);
+            }
+            return false;
+        }
+
+        public boolean areSignsEqual(SignWrapper other) {
+            return areSignsEqual(this, other);
+        }
+
+        public static boolean areSignsEqual(SignWrapper a, SignWrapper b) {
+            String[] aLines = a.rawLines();
+            String[] bLines = b.rawLines();
+
+            if (aLines.length != bLines.length) {
+                return false;
+            }
+
+            for (int i = 0; i < aLines.length; i++) {
+                String aLine = aLines[i].trim();
+                String bLine = bLines[i].trim();
+
+                if (!aLine.equalsIgnoreCase(bLine)) {
+                    return false;
+                }
+            }
+
+            // Now check the facing too!
+            return a.facing().equals(b.facing());
+        }
+
+        public static boolean areSignsEqual(SignWrapper[] a, SignWrapper[] b) {
+            if (a == null || b == null) {
+                return false;
+            }
+            if (a.length != b.length) {
+                return false;
+            }
+
+            for (int i = 0; i < a.length; i++) {
+                SignWrapper aWrap = a[i];
+                SignWrapper bWrap = b[i];
+                if (!areSignsEqual(aWrap, bWrap)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void copyContent(SignWrapper other) {
+            for (int i = 0; i < this.lines().size() && i < other.lines().size(); i++) {
+                this.line(i, other.line(i));
+            }
+        }
+
+    }
+
+    public SignWrapper[] getSignWrappers(Sign sign) {
+        return getSignWrappers(sign, false);
+    };
+    public abstract SignWrapper[] getSignWrappers(Sign sign, boolean ignoreEmpty);
+    protected abstract SignWrapper getSignWrapper(Sign sign, SignChangeEvent signChangeEvent);
+    protected abstract SignWrapper getSignWrapper(Sign sign, PlayerInteractEvent interactEvent);
+
+    public abstract void processSignTranslation(final Craft craft, boolean checkEventIsUpdated);
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onCraftDetect(CraftDetectEvent event) {
+        final World world = event.getCraft().getWorld();
+        event.getCraft().getHitBox().forEach(
+                (mloc) -> {
+                    Block block = mloc.toBukkit(world).getBlock();
+                    BlockState state = block.getState();
+                    if (state instanceof Sign sign) {
+                        for (SignWrapper wrapper : this.getSignWrappers(sign)) {
+                            AbstractCraftSign.tryGetCraftSign(wrapper.line(0)).ifPresent(acs -> acs.onCraftDetect(event, wrapper));
+                        }
+                    }
+                }
+        );
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onSignTranslate(SignTranslateEvent event) {
+        AbstractCraftSign.tryGetCraftSign(event.line(0)).ifPresent(acs -> acs.onSignMovedByCraft(event));
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onSignChange(SignChangeEvent event) {
+        Block block = event.getBlock();
+        BlockState state = block.getState();
+        if (state instanceof Sign sign) {
+            SignWrapper wrapper = this.getSignWrapper(sign, event);
+            AbstractMovecraftSign.tryGet(wrapper.line(0)).ifPresent(ams -> {
+
+                boolean success = ams.processSignChange(event, wrapper);
+                if (ams.shouldCancelEvent(success, null, event.getPlayer().isSneaking())) {
+                    event.setCancelled(true);
+                }
+            });
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onSignClick(PlayerInteractEvent event) {
+        Block block = event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
+        BlockState state = block.getState();
+        if (state instanceof Sign sign) {
+            SignWrapper wrapper = this.getSignWrapper(sign, event);
+            AbstractMovecraftSign.tryGet(wrapper.line(0)).ifPresent(ams -> {
+                boolean success = ams.processSignClick(event.getAction(), wrapper, event.getPlayer());
+                if (ams.shouldCancelEvent(success, event.getAction(), event.getPlayer().isSneaking())) {
+                    event.setCancelled(true);
+                }
+            });
+        }
+    }
+
+}

--- a/api/src/main/java/net/countercraft/movecraft/sign/AbstractSubcraftSign.java
+++ b/api/src/main/java/net/countercraft/movecraft/sign/AbstractSubcraftSign.java
@@ -1,0 +1,178 @@
+package net.countercraft.movecraft.sign;
+
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.PlayerCraft;
+import net.countercraft.movecraft.craft.type.CraftType;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public abstract class AbstractSubcraftSign extends AbstractCraftSign {
+
+    // TODO: Replace by writing to the signs nbt data
+    protected static final Set<MovecraftLocation> IN_USE = Collections.synchronizedSet(new HashSet<>());
+
+    protected final Function<String, @Nullable CraftType> craftTypeRetrievalFunction;
+
+    protected final Supplier<Plugin> pluginInstance;
+
+    public AbstractSubcraftSign(Function<String, @Nullable CraftType> craftTypeRetrievalFunction, final Supplier<Plugin> plugin) {
+        this(null, craftTypeRetrievalFunction, plugin);
+    }
+
+    public AbstractSubcraftSign(final String permission, Function<String, @Nullable CraftType> craftTypeRetrievalFunction, final Supplier<Plugin> plugin) {
+        super(permission, false);
+        this.craftTypeRetrievalFunction = craftTypeRetrievalFunction;
+        this.pluginInstance = plugin;
+    }
+
+    @Override
+    public boolean processSignClick(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        if (!this.isSignValid(clickType, sign, player)) {
+            return false;
+        }
+        if (!this.canPlayerUseSign(clickType, sign, player)) {
+            return false;
+        }
+        Craft craft = this.getCraft(sign);
+
+        if (craft instanceof PlayerCraft pc) {
+            if (!pc.isNotProcessing() && !this.ignoreCraftIsBusy) {
+                this.onCraftIsBusy(player, craft);
+                return false;
+            }
+        }
+
+        return internalProcessSign(clickType, sign, player, craft);
+    }
+
+    @Override
+    protected boolean internalProcessSign(Action clickType, AbstractSignListener.SignWrapper sign, Player player, Craft craft) {
+        if (craft != null) {
+            // TODO: Add property to crafts that they can use subcrafts?
+            if (!this.canPlayerUseSignOn(player, craft)) {
+                return false;
+            }
+        }
+        return this.internalProcessSignWithCraft(clickType, sign, craft, player);
+    }
+
+    @Override
+    public boolean shouldCancelEvent(boolean processingSuccessful, @Nullable Action type, boolean sneaking) {
+        return processingSuccessful || !sneaking;
+    }
+
+    @Override
+    public boolean processSignChange(SignChangeEvent event, AbstractSignListener.SignWrapper sign) {
+        // TODO: Implement
+        return false;
+    }
+
+    @Override
+    protected boolean isSignValid(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        String[] headerSplit = sign.getRaw(0).split(" ");
+        if (headerSplit.length != 2) {
+            return false;
+        }
+        // TODO: Change to enums?
+        String action = headerSplit[headerSplit.length - 1].toUpperCase();
+        if (!this.isActionAllowed(action)) {
+            return false;
+        }
+        return this.getCraftType(sign) != null;
+    }
+
+    @Override
+    protected boolean canPlayerUseSign(Action clickType, AbstractSignListener.SignWrapper sign, Player player) {
+        if (!super.canPlayerUseSign(clickType, sign, player)) {
+            return false;
+        }
+        CraftType craftType = this.getCraftType(sign);
+        if (craftType != null) {
+            return player.hasPermission("movecraft." + craftType.getStringProperty(CraftType.NAME) + ".pilot") && this.canPlayerUseSignForCraftType(clickType, sign, player, craftType);
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean internalProcessSignWithCraft(Action clickType, AbstractSignListener.SignWrapper sign, @Nullable Craft craft, Player player) {
+        CraftType subcraftType = this.getCraftType(sign);
+
+        final Location signLoc = sign.block().getLocation();
+        final MovecraftLocation startPoint = new MovecraftLocation(signLoc.getBlockX(), signLoc.getBlockY(), signLoc.getBlockZ());
+
+        if (craft != null) {
+            craft.setProcessing(true);
+            // TODO: SOlve this more elegantly...
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    craft.setProcessing(false);
+                }
+            }.runTaskLater(this.pluginInstance.get(), (10));
+        }
+
+        if (!IN_USE.add(startPoint)) {
+            this.onActionAlreadyInProgress(player);
+            return true;
+        }
+
+        this.applyDefaultText(sign);
+
+        final World world = sign.block().getWorld();
+
+        this.runDetectTask(clickType, subcraftType, craft, world, player, startPoint);
+
+        // TODO: Change this, it is ugly, should be done by the detect task itself
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                IN_USE.remove(startPoint);
+            }
+        }.runTaskLater(this.pluginInstance.get(), 4);
+
+        return false;
+    }
+
+    protected void applyDefaultText(AbstractSignListener.SignWrapper sign) {
+        if (sign.getRaw(2).isBlank() && sign.getRaw(3).isBlank()) {
+            Component l3 = this.getDefaultTextFor(2);
+            Component l4 = this.getDefaultTextFor(3);
+            if (l3 != null) {
+                sign.line(2, l3);
+            }
+            if (l4 != null) {
+                sign.line(2, l4);
+            }
+        }
+    }
+
+    @Nullable
+    protected CraftType getCraftType(AbstractSignListener.SignWrapper wrapper) {
+        String ident = wrapper.getRaw(2);
+        if (ident.trim().isBlank()) {
+            return null;
+        }
+        return this.craftTypeRetrievalFunction.apply(ident);
+    }
+
+    protected abstract void runDetectTask(Action clickType, CraftType subcraftType, Craft parentCraft, World world, Player player, MovecraftLocation startPoint);
+    protected abstract boolean isActionAllowed(final String action);
+    protected abstract void onActionAlreadyInProgress(Player player);
+    protected abstract Component getDefaultTextFor(int line);
+    protected abstract boolean canPlayerUseSignForCraftType(Action clickType, AbstractSignListener.SignWrapper sign, Player player, CraftType subCraftType);
+
+}

--- a/v1_18/src/main/java/net/countercraft/movecraft/compat/v1_18/SignListener.java
+++ b/v1_18/src/main/java/net/countercraft/movecraft/compat/v1_18/SignListener.java
@@ -1,0 +1,136 @@
+package net.countercraft.movecraft.compat.v1_18;
+
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.sign.AbstractSignListener;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.Directional;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.*;
+
+/*
+ * As soon as 1.18 support is dropped, the adapter system will be dropped too
+ */
+@Deprecated(forRemoval = true)
+public class SignListener extends AbstractSignListener {
+
+    protected final SignWrapper createFromSign(final Sign sign) {
+        BlockFace face = ((Directional) sign.getBlockData()).getFacing();
+        SignWrapper wrapper = new SignWrapper(
+                sign,
+                sign::line,
+                sign.lines(),
+                sign::line,
+                face
+        );
+        return wrapper;
+    }
+
+    @Override
+    public SignWrapper[] getSignWrappers(Sign sign, boolean ignoreEmpty) {
+        SignWrapper wrapper = this.createFromSign(sign);
+        if (ignoreEmpty && wrapper.isEmpty()) {
+            return new SignWrapper[] {};
+        }
+        return new SignWrapper[] {wrapper};
+    }
+
+    @Override
+    protected SignWrapper getSignWrapper(Sign sign, SignChangeEvent signChangeEvent) {
+        BlockFace face = ((Directional) sign.getBlockData()).getFacing();
+        SignWrapper wrapper = new SignWrapper(
+                sign,
+                signChangeEvent::line,
+                signChangeEvent.lines(),
+                signChangeEvent::line,
+                face
+        );
+        return wrapper;
+    }
+
+    @Override
+    protected SignWrapper getSignWrapper(Sign sign, PlayerInteractEvent interactEvent) {
+        return this.createFromSign(sign);
+    }
+
+    @Override
+    public void processSignTranslation(Craft craft, boolean checkEventIsUpdated) {
+        Object2ObjectMap<SignWrapper, List<MovecraftLocation>> signs = new Object2ObjectOpenCustomHashMap<>(new Hash.Strategy<SignWrapper>() {
+            @Override
+            public int hashCode(SignWrapper strings) {
+                return Arrays.hashCode(strings.rawLines());
+            }
+
+            @Override
+            public boolean equals(SignWrapper a, SignWrapper b) {
+                return SignWrapper.areSignsEqual(a, b);
+            }
+        });
+        Map<MovecraftLocation, SignWrapper[]> signStates = new HashMap<>();
+
+        for (MovecraftLocation location : craft.getHitBox()) {
+            Block block = location.toBukkit(craft.getWorld()).getBlock();
+            if(!Tag.SIGNS.isTagged(block.getType())){
+                continue;
+            }
+            BlockState state = block.getState();
+            if (state instanceof Sign) {
+                Sign sign = (Sign) state;
+                SignWrapper[] wrappersAtLoc = this.getSignWrappers(sign, true);
+                if (wrappersAtLoc == null || wrappersAtLoc.length == 0) {
+                    continue;
+                }
+                for (SignWrapper wrapper : wrappersAtLoc) {
+                    List<MovecraftLocation> values = signs.computeIfAbsent(wrapper, (w) -> new ArrayList<>());
+                    values.add(location);
+                }
+                signStates.put(location, wrappersAtLoc);
+            }
+        }
+        // TODO: This is not good yet, this doesn't really care about a signs sides...
+        for(Map.Entry<SignWrapper, List<MovecraftLocation>> entry : signs.entrySet()){
+            final List<Component> components = new ArrayList<>(entry.getKey().lines());
+            SignWrapper backingForEvent = new SignWrapper(null, components::get, components, components::set, entry.getKey().facing());
+            SignTranslateEvent event = new SignTranslateEvent(craft, backingForEvent, entry.getValue());
+            Bukkit.getServer().getPluginManager().callEvent(event);
+            // if(!event.isUpdated()){
+            //     continue;
+            // }
+            // TODO: This is implemented only to fix client caching
+            //  ideally we wouldn't do the update and would instead fake it out to the player
+            for(MovecraftLocation location : entry.getValue()){
+                Block block = location.toBukkit(craft.getWorld()).getBlock();
+                BlockState state = block.getState();
+                if (!(state instanceof Sign)) {
+                    continue;
+                }
+                SignWrapper[] signsAtLoc = signStates.get(location);
+                if (signsAtLoc != null && signsAtLoc.length > 0) {
+                    for (SignWrapper sw : signsAtLoc) {
+                        if (!checkEventIsUpdated || event.isUpdated()) {
+                            sw.copyContent(entry.getKey());
+                        }
+                    }
+                    try {
+                        ((Sign)location.toBukkit(craft.getWorld()).getBlock()).update(false, false);
+                    } catch(ClassCastException ex) {
+                        // Ignore
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/v1_20/src/main/java/net/countercraft/movecraft/compat/v1_20/SignListener.java
+++ b/v1_20/src/main/java/net/countercraft/movecraft/compat/v1_20/SignListener.java
@@ -1,0 +1,160 @@
+package net.countercraft.movecraft.compat.v1_20;
+
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.sign.AbstractSignListener;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.Directional;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/*
+ * As soon as 1.18 support is dropped, the adapter system will be dropped too
+ */
+@Deprecated(forRemoval = true)
+public class SignListener extends AbstractSignListener {
+
+    protected final SignWrapper createFromSide(final Sign sign, final Side side) {
+        SignSide signSide = sign.getSide(side);
+        return createFromSide(sign, signSide, side);
+    }
+
+    protected final SignWrapper createFromSide(final Sign sign, final SignSide signSide, Side side) {
+        BlockFace face = ((Directional) sign.getBlockData()).getFacing();
+        if (side == Side.BACK) {
+            face = face.getOppositeFace();
+        }
+        SignWrapper wrapper = new SignWrapper(
+                sign,
+                signSide::line,
+                signSide.lines(),
+                signSide::line,
+                face
+        );
+        return wrapper;
+    }
+
+    @Override
+    public SignWrapper[] getSignWrappers(Sign sign, boolean ignoreEmpty) {
+        Side[] sides = new Side[Side.values().length];
+        List<SignWrapper> wrappers = new ArrayList<>();
+        for (int i = 0; i < sides.length; i++) {
+            Side side = sides[i];
+            SignSide signSide = sign.getSide(side);
+            SignWrapper wrapper = this.createFromSide(sign, signSide, side);
+            wrappers.add(wrapper);
+        }
+        if (ignoreEmpty)
+            wrappers.removeIf(SignWrapper::isEmpty);
+        return wrappers.toArray(new SignWrapper[wrappers.size()]);
+    }
+
+    @Override
+    protected SignWrapper getSignWrapper(Sign sign, SignChangeEvent signChangeEvent) {
+        @NotNull Side side = signChangeEvent.getSide();
+        BlockFace face = ((Directional) sign.getBlockData()).getFacing();
+        if (side == Side.BACK) {
+            face = face.getOppositeFace();
+        }
+        SignWrapper wrapper = new SignWrapper(
+                sign,
+                signChangeEvent::line,
+                signChangeEvent.lines(),
+                signChangeEvent::line,
+                face
+        );
+        return wrapper;
+    }
+
+    @Override
+    protected SignWrapper getSignWrapper(Sign sign, PlayerInteractEvent interactEvent) {
+        @NotNull SignSide side = sign.getTargetSide(interactEvent.getPlayer());
+        return this.createFromSide(sign, side, sign.getInteractableSideFor(interactEvent.getPlayer()));
+    }
+
+    @Override
+    public void processSignTranslation(Craft craft, boolean checkEventIsUpdated) {
+        Object2ObjectMap<SignWrapper, List<MovecraftLocation>> signs = new Object2ObjectOpenCustomHashMap<>(new Hash.Strategy<SignWrapper>() {
+            @Override
+            public int hashCode(SignWrapper strings) {
+                return Arrays.hashCode(strings.rawLines()) * strings.facing().hashCode();
+            }
+
+            @Override
+            public boolean equals(SignWrapper a, SignWrapper b) {
+                return SignWrapper.areSignsEqual(a, b);
+            }
+        });
+        Map<MovecraftLocation, SignWrapper[]> signStates = new HashMap<>();
+
+        for (MovecraftLocation location : craft.getHitBox()) {
+            Block block = location.toBukkit(craft.getWorld()).getBlock();
+            if(!Tag.SIGNS.isTagged(block.getType())){
+                continue;
+            }
+            BlockState state = block.getState();
+            if (state instanceof Sign) {
+                Sign sign = (Sign) state;
+                SignWrapper[] wrappersAtLoc = this.getSignWrappers(sign, true);
+                if (wrappersAtLoc == null || wrappersAtLoc.length == 0) {
+                    continue;
+                }
+                for (SignWrapper wrapper : wrappersAtLoc) {
+                    List<MovecraftLocation> values = signs.computeIfAbsent(wrapper, (w) -> new ArrayList<>());
+                    values.add(location);
+                }
+                signStates.put(location, wrappersAtLoc);
+            }
+        }
+        for(Map.Entry<SignWrapper, List<MovecraftLocation>> entry : signs.entrySet()){
+            final List<Component> components = new ArrayList<>(entry.getKey().lines());
+            SignWrapper backingForEvent = new SignWrapper(null, components::get, components, components::set, entry.getKey().facing());
+            SignTranslateEvent event = new SignTranslateEvent(craft, backingForEvent, entry.getValue());
+            Bukkit.getServer().getPluginManager().callEvent(event);
+            // if(!event.isUpdated()){
+            //     continue;
+            // }
+            // TODO: This is implemented only to fix client caching
+            //  ideally we wouldn't do the update and would instead fake it out to the player
+            for(MovecraftLocation location : entry.getValue()){
+                Block block = location.toBukkit(craft.getWorld()).getBlock();
+                BlockState state = block.getState();
+                if (!(state instanceof Sign)) {
+                    continue;
+                }
+                SignWrapper[] signsAtLoc = signStates.get(location);
+                if (signsAtLoc != null && signsAtLoc.length > 0) {
+                    for (SignWrapper sw : signsAtLoc) {
+                        // Important: Check if the wrapper faces the right way!
+                        if (!sw.facing().equals(entry.getKey().facing())) {
+                            continue;
+                        }
+                        if (!checkEventIsUpdated || event.isUpdated()) {
+                            sw.copyContent(entry.getKey());
+                        }
+                    }
+                    try {
+                        ((Sign)location.toBukkit(craft.getWorld()).getBlock()).update(false, false);
+                    } catch(ClassCastException ex) {
+                        // Ignore
+                    }
+                }
+            }
+        }
+    }
+}

--- a/v1_21/src/main/java/net/countercraft/movecraft/compat/v1_21/SignListener.java
+++ b/v1_21/src/main/java/net/countercraft/movecraft/compat/v1_21/SignListener.java
@@ -1,0 +1,160 @@
+package net.countercraft.movecraft.compat.v1_21;
+
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.events.SignTranslateEvent;
+import net.countercraft.movecraft.sign.AbstractSignListener;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.Directional;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/*
+ * As soon as 1.18 support is dropped, the adapter system will be dropped too
+ */
+@Deprecated(forRemoval = true)
+public class SignListener extends AbstractSignListener {
+
+    protected final SignWrapper createFromSide(final Sign sign, final Side side) {
+        SignSide signSide = sign.getSide(side);
+        return createFromSide(sign, signSide, side);
+    }
+
+    protected final SignWrapper createFromSide(final Sign sign, final SignSide signSide, Side side) {
+        BlockFace face = ((Directional) sign.getBlockData()).getFacing();
+        if (side == Side.BACK) {
+            face = face.getOppositeFace();
+        }
+        SignWrapper wrapper = new SignWrapper(
+                sign,
+                signSide::line,
+                signSide.lines(),
+                signSide::line,
+                face
+        );
+        return wrapper;
+    }
+
+    @Override
+    public SignWrapper[] getSignWrappers(Sign sign, boolean ignoreEmpty) {
+        Side[] sides = new Side[Side.values().length];
+        List<SignWrapper> wrappers = new ArrayList<>();
+        for (int i = 0; i < sides.length; i++) {
+            Side side = sides[i];
+            SignSide signSide = sign.getSide(side);
+            SignWrapper wrapper = this.createFromSide(sign, signSide, side);
+            wrappers.add(wrapper);
+        }
+        if (ignoreEmpty)
+            wrappers.removeIf(SignWrapper::isEmpty);
+        return wrappers.toArray(new SignWrapper[wrappers.size()]);
+    }
+
+    @Override
+    protected SignWrapper getSignWrapper(Sign sign, SignChangeEvent signChangeEvent) {
+        @NotNull Side side = signChangeEvent.getSide();
+        BlockFace face = ((Directional) sign.getBlockData()).getFacing();
+        if (side == Side.BACK) {
+            face = face.getOppositeFace();
+        }
+        SignWrapper wrapper = new SignWrapper(
+                sign,
+                signChangeEvent::line,
+                signChangeEvent.lines(),
+                signChangeEvent::line,
+                face
+        );
+        return wrapper;
+    }
+
+    @Override
+    protected SignWrapper getSignWrapper(Sign sign, PlayerInteractEvent interactEvent) {
+        @NotNull SignSide side = sign.getTargetSide(interactEvent.getPlayer());
+        return this.createFromSide(sign, side, sign.getInteractableSideFor(interactEvent.getPlayer()));
+    }
+
+    @Override
+    public void processSignTranslation(Craft craft, boolean checkEventIsUpdated) {
+        Object2ObjectMap<SignWrapper, List<MovecraftLocation>> signs = new Object2ObjectOpenCustomHashMap<>(new Hash.Strategy<SignWrapper>() {
+            @Override
+            public int hashCode(SignWrapper strings) {
+                return Arrays.hashCode(strings.rawLines()) * strings.facing().hashCode();
+            }
+
+            @Override
+            public boolean equals(SignWrapper a, SignWrapper b) {
+                return SignWrapper.areSignsEqual(a, b);
+            }
+        });
+        Map<MovecraftLocation, SignWrapper[]> signStates = new HashMap<>();
+
+        for (MovecraftLocation location : craft.getHitBox()) {
+            Block block = location.toBukkit(craft.getWorld()).getBlock();
+            if(!Tag.SIGNS.isTagged(block.getType())){
+                continue;
+            }
+            BlockState state = block.getState();
+            if (state instanceof Sign) {
+                Sign sign = (Sign) state;
+                SignWrapper[] wrappersAtLoc = this.getSignWrappers(sign, true);
+                if (wrappersAtLoc == null || wrappersAtLoc.length == 0) {
+                    continue;
+                }
+                for (SignWrapper wrapper : wrappersAtLoc) {
+                    List<MovecraftLocation> values = signs.computeIfAbsent(wrapper, (w) -> new ArrayList<>());
+                    values.add(location);
+                }
+                signStates.put(location, wrappersAtLoc);
+            }
+        }
+        for(Map.Entry<SignWrapper, List<MovecraftLocation>> entry : signs.entrySet()){
+            final List<Component> components = new ArrayList<>(entry.getKey().lines());
+            SignWrapper backingForEvent = new SignWrapper(null, components::get, components, components::set, entry.getKey().facing());
+            SignTranslateEvent event = new SignTranslateEvent(craft, backingForEvent, entry.getValue());
+            Bukkit.getServer().getPluginManager().callEvent(event);
+            // if(!event.isUpdated()){
+            //     continue;
+            // }
+            // TODO: This is implemented only to fix client caching
+            //  ideally we wouldn't do the update and would instead fake it out to the player
+            for(MovecraftLocation location : entry.getValue()){
+                Block block = location.toBukkit(craft.getWorld()).getBlock();
+                BlockState state = block.getState();
+                if (!(state instanceof Sign)) {
+                    continue;
+                }
+                SignWrapper[] signsAtLoc = signStates.get(location);
+                if (signsAtLoc != null && signsAtLoc.length > 0) {
+                    for (SignWrapper sw : signsAtLoc) {
+                        // Important: Check if the wrapper faces the right way!
+                        if (!sw.facing().equals(entry.getKey().facing())) {
+                            continue;
+                        }
+                        if (!checkEventIsUpdated || event.isUpdated()) {
+                            sw.copyContent(entry.getKey());
+                        }
+                    }
+                    try {
+                        ((Sign)location.toBukkit(craft.getWorld()).getBlock()).update(false, false);
+                    } catch(ClassCastException ex) {
+                        // Ignore
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
As discussed with @oh-noey the original PR (#679 ) is being splitted into two parts.
The first part (this PR) being the necessary API classes and changes ONLY.

That contains the base classes for all signs as well as their registration and the sign wrapper shenanigans.

This does not yet contain the necessary changes to TranslationTask.java and RotationTask.java as those changes need to be looked at again. Most of the change is switching to a call to the signListener instance though.

### Checklist
- [ ] Tested
- [ ] Performance tested (Could improve performance, but mainly makes the sign behaviors extendalbe and overridable in a nicer way. Also reduces duplicate code)
