### PR TITLE
Fix bad performance with passthroughblocks

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -118,12 +118,13 @@ public class CraftRotateCommand extends UpdateCommand {
                 validExterior.addAll(hitBox.difference(craft.getHitBox()));
             }
             //Check to see which locations in the from set are actually outside of the craft
+            SetHitBox visited = new SetHitBox();
             for (MovecraftLocation location : validExterior) {
                 if (craft.getHitBox().contains(location) || exterior.contains(location)) {
                     continue;
                 }
                 //use a modified BFS for multiple origin elements
-                SetHitBox visited = new SetHitBox();
+                
                 Queue<MovecraftLocation> queue = new LinkedList<>();
                 queue.add(location);
                 while (!queue.isEmpty()) {
@@ -136,9 +137,9 @@ public class CraftRotateCommand extends UpdateCommand {
                         visited.add(neighbor);
                         queue.add(neighbor);
                     }
-                }
-                exterior.addAll(visited);
+                }               
             }
+            exterior.addAll(visited);
             interior.addAll(invertedHitBox.difference(exterior));
 
             final WorldHandler handler = Movecraft.getInstance().getWorldHandler();

--- a/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/mapUpdater/update/CraftRotateCommand.java
@@ -131,11 +131,13 @@ public class CraftRotateCommand extends UpdateCommand {
                     MovecraftLocation node = queue.poll();
                     //If the node is already a valid member of the exterior of the HitBox, continued search is unitary.
                     for (MovecraftLocation neighbor : CollectionUtils.neighbors(invertedHitBox, node)) {
-                        if (visited.contains(neighbor)) {
-                            continue;
+                        // This is a set! If it already contains the element, it won't add it anyway!
+                        //if (visited.contains(neighbor)) {
+                        //    continue;
+                        //}
+                        if (visited.add(neighbor)) {
+                            queue.add(neighbor);
                         }
-                        visited.add(neighbor);
-                        queue.add(neighbor);
                     }
                 }               
             }


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
As discussed on discord, this moves the creation of visited in front of the loop and addAll of exterior to after the loop

### Checklist
- [ ] Tested
- [ ] Performance tested => will do tomorrow
