### PR TITLE
[Bugfix] Fix infinite loop in TranslationTask

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -229,12 +229,8 @@ public class TranslationTask extends AsyncTask {
             MovecraftLocation test = new MovecraftLocation(newHitBox.getMidPoint().getX(), newHitBox.getMinY(),
                     newHitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
-            while (test.toBukkit(world).getBlock().getType().isAir()) {
-                // If we are out of bounds, that is technically air, but can we hover over ground???
-                if (test.getY() < world.getMinHeight()) {
-                    fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over void")));
-                    return;
-                }
+            // If we are out of bounds, that is technically air, but then we would have an infinite loop, so stay in Y bounds
+            while (test.toBukkit(world).getBlock().getType().isAir() && world.getMinHeight() >= test.getY() && world.getMaxHeight() <= test.getY()) {
                 test = test.translate(0, -1, 0);
             }
             Material testType = test.toBukkit(world).getBlock().getType();

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -230,12 +230,19 @@ public class TranslationTask extends AsyncTask {
                     newHitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
             while (test.toBukkit(world).getBlock().getType().isAir()) {
+                // If we are out of bounds, that is technically air, but can we hover over ground???
+                if (test.getY() < world.getMinHeight()) {
+                    fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over void"))));
+                    return;
+                }
                 test = test.translate(0, -1, 0);
             }
             Material testType = test.toBukkit(world).getBlock().getType();
             if (craft.getType().getMaterialSetProperty(CraftType.FORBIDDEN_HOVER_OVER_BLOCKS).contains(testType)) {
+                // Why is there no return here? Shouldnt there be one?
                 fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over block"),
                         testType.name().toLowerCase().replace("_", " ")));
+                return;
             }
         }
         //call event

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -230,7 +230,7 @@ public class TranslationTask extends AsyncTask {
                     newHitBox.getMidPoint().getZ());
             test = test.translate(0, -1, 0);
             // If we are out of bounds, that is technically air, but then we would have an infinite loop, so stay in Y bounds
-            while (test.toBukkit(world).getBlock().getType().isAir() && world.getMinHeight() >= test.getY() && world.getMaxHeight() <= test.getY()) {
+            while (test.toBukkit(world).getBlock().getType().isAir() && world.getMinHeight() >= test.getY()) {
                 test = test.translate(0, -1, 0);
             }
             Material testType = test.toBukkit(world).getBlock().getType();

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -232,7 +232,7 @@ public class TranslationTask extends AsyncTask {
             while (test.toBukkit(world).getBlock().getType().isAir()) {
                 // If we are out of bounds, that is technically air, but can we hover over ground???
                 if (test.getY() < world.getMinHeight()) {
-                    fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over void"))));
+                    fail(String.format(I18nSupport.getInternationalisedString("Translation - Failed Craft over void")));
                     return;
                 }
                 test = test.translate(0, -1, 0);

--- a/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
+++ b/Movecraft/src/main/resources/localisation/movecraftlang_en.properties
@@ -112,6 +112,7 @@ Translation\ -\ Failed\ Craft\ is\ obstructed=The craft cannot move because its 
 Translation\ -\ Failed\ Craft\ out\ of\ fuel=The craft is out of fuel\!
 Translation\ -\ Failed\ Craft\ hit\ minimum\ height\ limit=Craft has hit the minimum height limit
 Translation\ -\ Failed\ Craft\ over\ block=This craft cannot move over %s\!
+Translation\ -\ Failed\ Craft\ over\ void=The craft can't go over nonexisting terrain!
 
 Insufficient\ Permissions=Insufficient Permissions
 Invalid\ Coordinates=Invalid Coordinates


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
There is a infinite loop in TranslationTask.java in the validation for forbidden hover blocks. In short, the position moves out of worldspace and thus the returned block will always be air, resulting in a infinite loop.

Also fixed a probably missing return statement further down, if a block was found that can't be hovered over

### Related issues:
- dont know of one, but this bug is known on TTE and strangelands

### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Tested
