### PR TITLE
Fix/Add tracked locations rotating on subcrafts

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -165,6 +165,8 @@ public class RotationTask extends AsyncTask {
         }
 
         // Rotates the craft's tracked locations, and all parent craft's.
+        // First, rotate the refernce point!
+        craft.getCraftOrigin().rotate(originPoint, rotation);
         Craft temp = craft;
         // recursion through all subcrafts is not necessary as the trackedlocations are transferred to the subcraft
         //do {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -166,13 +166,13 @@ public class RotationTask extends AsyncTask {
 
         // Rotates the craft's tracked locations, and all parent craft's.
         Craft temp = craft;
-        do {
-            for (Set<TrackedLocation> locations : craft.getTrackedLocations().values()) {
+        //do {
+            for (Set<TrackedLocation> locations : temp.getTrackedLocations().values()) {
                 for (TrackedLocation location : locations) {
                     location.rotate(rotation, originPoint);
                 }
             }
-        } while (temp instanceof SubCraft && (temp = ((SubCraft) temp).getParent()) != null);
+        //} while (temp instanceof SubCraft && (temp = ((SubCraft) temp).getParent()) != null);
 
         updates.add(new CraftRotateCommand(getCraft(),originPoint, rotation));
         //rotate entities in the craft

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -169,7 +169,10 @@ public class RotationTask extends AsyncTask {
         //do {
             for (Set<TrackedLocation> locations : temp.getTrackedLocations().values()) {
                 for (TrackedLocation location : locations) {
+                    System.out.println("ROTATING");
+                    System.out.println("Original absolute: " + location.getAbsoluteLocation());
                     location.rotate(rotation, originPoint);
+                    System.out.println("ROTATING END");
                 }
             }
         //} while (temp instanceof SubCraft && (temp = ((SubCraft) temp).getParent()) != null);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -169,10 +169,7 @@ public class RotationTask extends AsyncTask {
         //do {
             for (Set<TrackedLocation> locations : temp.getTrackedLocations().values()) {
                 for (TrackedLocation location : locations) {
-                    System.out.println("ROTATING");
-                    System.out.println("Original absolute: " + location.getAbsoluteLocation());
                     location.rotate(rotation, originPoint);
-                    System.out.println("ROTATING END");
                 }
             }
         //} while (temp instanceof SubCraft && (temp = ((SubCraft) temp).getParent()) != null);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -165,8 +165,6 @@ public class RotationTask extends AsyncTask {
         }
 
         // Rotates the craft's tracked locations, and all parent craft's.
-        // First, rotate the refernce point!
-        craft.getCraftOrigin().rotate(originPoint, rotation);
         Craft temp = craft;
         // recursion through all subcrafts is not necessary as the trackedlocations are transferred to the subcraft
         //do {
@@ -176,6 +174,8 @@ public class RotationTask extends AsyncTask {
                 }
             }
         //} while (temp instanceof SubCraft && (temp = ((SubCraft) temp).getParent()) != null);
+        // Lastly, rotate the refernce point as the trackedlocations need the center at the old location while it rotates!!
+        craft.getCraftOrigin().rotate(originPoint, rotation);
 
         updates.add(new CraftRotateCommand(getCraft(),originPoint, rotation));
         //rotate entities in the craft

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -165,7 +165,9 @@ public class RotationTask extends AsyncTask {
         }
 
         // Rotates the craft's tracked locations, and all parent craft's.
-        craft.getCraftOrigin().rotate(originPoint, rotation);
+        MovecraftLocation oldOrigin = craft.getCraftOrigin();
+        MovecraftLocation vectorRotated = MathUtils.rotateVec(rotation, oldOrigin.subtract(originPoint));
+        craft.setDataTag(Craft.CRAFT_ORIGIN, originPoint.add(vectorRotated));
         Craft temp = craft;
         // recursion through all subcrafts is not necessary as the trackedlocations are transferred to the subcraft
         //do {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -166,6 +166,7 @@ public class RotationTask extends AsyncTask {
 
         // Rotates the craft's tracked locations, and all parent craft's.
         Craft temp = craft;
+        // recursion through all subcrafts is not necessary as the trackedlocations are transferred to the subcraft
         //do {
             for (Set<TrackedLocation> locations : temp.getTrackedLocations().values()) {
                 for (TrackedLocation location : locations) {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/rotation/RotationTask.java
@@ -165,17 +165,16 @@ public class RotationTask extends AsyncTask {
         }
 
         // Rotates the craft's tracked locations, and all parent craft's.
+        craft.getCraftOrigin().rotate(originPoint, rotation);
         Craft temp = craft;
         // recursion through all subcrafts is not necessary as the trackedlocations are transferred to the subcraft
         //do {
             for (Set<TrackedLocation> locations : temp.getTrackedLocations().values()) {
                 for (TrackedLocation location : locations) {
-                    location.rotate(rotation, originPoint);
+                    location.rotate(rotation);
                 }
             }
         //} while (temp instanceof SubCraft && (temp = ((SubCraft) temp).getParent()) != null);
-        // Lastly, rotate the refernce point as the trackedlocations need the center at the old location while it rotates!!
-        craft.getCraftOrigin().rotate(originPoint, rotation);
 
         updates.add(new CraftRotateCommand(getCraft(),originPoint, rotation));
         //rotate entities in the craft

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -319,7 +319,8 @@ public class TranslationTask extends AsyncTask {
             }
         }
 
-        updateTrackedLocations(craft, dx, dy, dz);
+        // Update the reference location for trackedlocations
+        craft.getCraftOrigin().translate(dx, dy, dz);
 
         if (!collisionBox.isEmpty() && craft.getType().getBoolProperty(CraftType.CRUISE_ON_PILOT)) {
             CraftManager.getInstance().release(craft, CraftReleaseEvent.Reason.EMPTY, false);
@@ -340,16 +341,6 @@ public class TranslationTask extends AsyncTask {
         //prevents torpedo and rocket pilots
         preventsTorpedoRocketsPilots();
         captureYield(harvestedBlocks);
-    }
-
-    protected void updateTrackedLocations(Craft craft, int dx, int dy, int dz) {
-        craft.getTrackedLocations().values().forEach(trackedLocations -> {
-            trackedLocations.forEach(
-                    trackedLocation -> {
-                        trackedLocation.translate(dx, dy, dz);
-                    }
-            );
-        });
     }
 
     private void preventsTorpedoRocketsPilots() {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -3,6 +3,7 @@ package net.countercraft.movecraft.async.translation;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftChunk;
 import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.TrackedLocation;
 import net.countercraft.movecraft.async.AsyncTask;
 import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.ChunkManager;
@@ -318,6 +319,8 @@ public class TranslationTask extends AsyncTask {
             }
         }
 
+        updateTrackedLocations(craft, dx, dy, dz);
+
         if (!collisionBox.isEmpty() && craft.getType().getBoolProperty(CraftType.CRUISE_ON_PILOT)) {
             CraftManager.getInstance().release(craft, CraftReleaseEvent.Reason.EMPTY, false);
             for (MovecraftLocation location : oldHitBox) {
@@ -337,6 +340,16 @@ public class TranslationTask extends AsyncTask {
         //prevents torpedo and rocket pilots
         preventsTorpedoRocketsPilots();
         captureYield(harvestedBlocks);
+    }
+
+    protected void updateTrackedLocations(Craft craft, int dx, int dy, int dz) {
+        craft.getTrackedLocations().values().forEach(trackedLocations -> {
+            trackedLocations.forEach(
+                    trackedLocation -> {
+                        trackedLocation.translate(dx, dy, dz);
+                    }
+            );
+        });
     }
 
     private void preventsTorpedoRocketsPilots() {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -320,7 +320,7 @@ public class TranslationTask extends AsyncTask {
         }
 
         // Update the reference location for trackedlocations
-        craft.getCraftOrigin().translate(dx, dy, dz);
+        craft.setDataTag(Craft.CRAFT_ORIGIN, craft.getCraftOrigin().translate(dx, dy, dz));
 
         if (!collisionBox.isEmpty() && craft.getType().getBoolProperty(CraftType.CRUISE_ON_PILOT)) {
             CraftManager.getInstance().release(craft, CraftReleaseEvent.Reason.EMPTY, false);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -79,7 +80,7 @@ public abstract class BaseCraft implements Craft {
     private String name = "";
     @NotNull
     private MovecraftLocation lastTranslation = new MovecraftLocation(0, 0, 0);
-    private Map<NamespacedKey, Set<TrackedLocation>> trackedLocations = new HashMap<>();
+    private Map<NamespacedKey, Set<TrackedLocation>> trackedLocations = new ConcurrentHashMap<>();
 
     @NotNull
     private final CraftDataTagContainer dataTagContainer;

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -56,7 +56,7 @@ public class CraftPilotListener implements Listener {
                     }
                 }
                 return false;
-            });
+            }, true);
         }
     }
 
@@ -85,14 +85,14 @@ public class CraftPilotListener implements Listener {
             }
         }
 
-        transferTrackedLocations(subCraft, subCraft.getParent(), Predicates.alwaysTrue());
+        transferTrackedLocations(subCraft, subCraft.getParent(), Predicates.alwaysTrue(), true);
     }
 
     /*
     * Transfers TrackedLocations from a craft A to a craft B with a optional filter.
     * This MOVES the tracked locations, so keep that in mind
     */
-    private static void transferTrackedLocations(final Craft a, final Craft b, Predicate<TrackedLocation> filterArgument) {
+    private static void transferTrackedLocations(final Craft a, final Craft b, Predicate<TrackedLocation> filterArgument, boolean move) {
         final MovecraftLocation bMidPoint = b.getHitBox().getMidPoint();
 
         for (Map.Entry<NamespacedKey, Set<TrackedLocation>> entry : a.getTrackedLocations().entrySet()) {
@@ -103,15 +103,21 @@ public class CraftPilotListener implements Listener {
                 continue;
             }
 
+            // Commented out code: previous attempt to actually transfer the tracked locations, which technically is unnecessary unless for subcrafts like squadrons that actually move!
             List<TrackedLocation> transferred = new ArrayList<>();
             aTrackedLocations.forEach(trackedLocation -> {
                 if (filterArgument.test(trackedLocation)) {
-                    final MovecraftLocation absoluteLocation = trackedLocation.getAbsoluteLocation();
-                    trackedLocation.reset(b, absoluteLocation);
-                    if (!(bTrackedLocations.add(trackedLocation))) {
-                        trackedLocation.reset(a, absoluteLocation);
+                    if (move) {
+
+                        final MovecraftLocation absoluteLocation = trackedLocation.getAbsoluteLocation();
+                        trackedLocation.reset(b, absoluteLocation);
+                        if (!(bTrackedLocations.add(trackedLocation))) {
+                            trackedLocation.reset(a, absoluteLocation);
+                        } else {
+                            transferred.add(trackedLocation);
+                        }
                     } else {
-                        transferred.add(trackedLocation);
+                        bTrackedLocations.add(trackedLocation);
                     }
                 }
             });

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -47,15 +47,7 @@ public class CraftPilotListener implements Listener {
             if (parent.getWorld() != subCraft.getWorld()) {
                 return;
             }
-            transferTrackedLocations(parent, subCraft, (trackedLocation) -> {
-                MovecraftLocation absolute = trackedLocation.getAbsoluteLocation();
-                if (subCraft.getHitBox().inBounds(absolute)) {
-                    if (subCraft.getHitBox().contains(absolute)) {
-                        return true;
-                    }
-                }
-                return false;
-            }, true);
+            transferTrackedLocations(parent, subCraft, (trackedLocation) -> subCraft.getHitBox().inBounds(trackedLocation.getAbsoluteLocation()) && subCraft.getHitBox().contains(trackedLocation.getAbsoluteLocation()), true);
         }
     }
 

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -109,9 +109,9 @@ public class CraftPilotListener implements Listener {
                     if (move) {
                         // Technically this (the reset call) is not necessary, but we will keep it here for potential extensions by third party addons
                         final MovecraftLocation absoluteLocation = trackedLocation.getAbsoluteLocation();
-                        trackedLocation.reset(absoluteLocation);
+                        trackedLocation.reset(b, absoluteLocation);
                         if (!(bTrackedLocations.add(trackedLocation))) {
-                            trackedLocation.reset(absoluteLocation);
+                            trackedLocation.reset(a, absoluteLocation);
                         } else {
                             transferred.add(trackedLocation);
                         }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -110,8 +110,8 @@ public class CraftPilotListener implements Listener {
 
             aTrackedLocations.removeIf(trackedLocation -> {
                 if (filterArgument.test(trackedLocation)) {
-                    TrackedLocation trackedLocationB = new TrackedLocation(b, trackedLocation.getAbsoluteLocation().subtract(bMidPoint));
-                    return bTrackedLocations.add(trackedLocationB);
+                    trackedLocation.reset(b, trackedLocation.getAbsoluteLocation());
+                    return bTrackedLocations.add(trackedLocation);
                 }
                 return false;
             });

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -108,14 +108,17 @@ public class CraftPilotListener implements Listener {
             aTrackedLocations.forEach(trackedLocation -> {
                 if (filterArgument.test(trackedLocation)) {
                     if (move) {
-
                         final MovecraftLocation absoluteLocation = trackedLocation.getAbsoluteLocation();
+                        System.out.println("TRANSFERRING");
+                        System.out.println("Original absolute: " + absoluteLocation.toString());
                         trackedLocation.reset(b, absoluteLocation);
                         if (!(bTrackedLocations.add(trackedLocation))) {
                             trackedLocation.reset(a, absoluteLocation);
                         } else {
                             transferred.add(trackedLocation);
                         }
+                        System.out.println("Absolute After Transfer: " + trackedLocation.getAbsoluteLocation().toString());
+                        System.out.println("TRANSFERRING END");
                     } else {
                         bTrackedLocations.add(trackedLocation);
                     }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -118,6 +118,9 @@ public class CraftPilotListener implements Listener {
                             transferred.add(trackedLocation);
                         }
                         System.out.println("Absolute After Transfer: " + trackedLocation.getAbsoluteLocation().toString());
+                        if (!absoluteLocation.equals(trackedLocation.getAbsoluteLocation())) {
+                            throw new IllegalStateException("Somehow the previous and transferred absolute locations are NOT the same! This should NEVER happen!");
+                        }
                         System.out.println("TRANSFERRING END");
                     } else {
                         bTrackedLocations.add(trackedLocation);

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -8,7 +8,6 @@ import net.countercraft.movecraft.craft.SubCraft;
 import net.countercraft.movecraft.events.CraftPilotEvent;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
-import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
@@ -108,20 +107,17 @@ public class CraftPilotListener implements Listener {
             aTrackedLocations.forEach(trackedLocation -> {
                 if (filterArgument.test(trackedLocation)) {
                     if (move) {
+                        // Technically this (the reset call) is not necessary, but we will keep it here for potential extensions by third party addons
                         final MovecraftLocation absoluteLocation = trackedLocation.getAbsoluteLocation();
-                        System.out.println("TRANSFERRING");
-                        System.out.println("Original absolute: " + absoluteLocation.toString());
-                        trackedLocation.reset(b, absoluteLocation);
+                        trackedLocation.reset(absoluteLocation);
                         if (!(bTrackedLocations.add(trackedLocation))) {
-                            trackedLocation.reset(a, absoluteLocation);
+                            trackedLocation.reset(absoluteLocation);
                         } else {
                             transferred.add(trackedLocation);
                         }
-                        System.out.println("Absolute After Transfer: " + trackedLocation.getAbsoluteLocation().toString());
                         if (!absoluteLocation.equals(trackedLocation.getAbsoluteLocation())) {
                             throw new IllegalStateException("Somehow the previous and transferred absolute locations are NOT the same! This should NEVER happen!");
                         }
-                        System.out.println("TRANSFERRING END");
                     } else {
                         bTrackedLocations.add(trackedLocation);
                     }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/CraftPilotListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -100,8 +101,8 @@ public class CraftPilotListener implements Listener {
         final MovecraftLocation bMidPoint = b.getHitBox().getMidPoint();
 
         for (Map.Entry<NamespacedKey, Set<TrackedLocation>> entry : a.getTrackedLocations().entrySet()) {
-            Set<TrackedLocation> bTrackedLocations = b.getTrackedLocations().getOrDefault(entry.getKey(), Set.of());
-            Set<TrackedLocation> aTrackedLocations = entry.getValue();
+            final Set<TrackedLocation> bTrackedLocations = b.getTrackedLocations().computeIfAbsent(entry.getKey(), k -> new HashSet<>());
+            final Set<TrackedLocation> aTrackedLocations = entry.getValue();
 
             if (aTrackedLocations.isEmpty()) {
                 continue;

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -1,12 +1,13 @@
 package net.countercraft.movecraft;
 
 import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.SubCraft;
 import net.countercraft.movecraft.util.MathUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class TrackedLocation {
     private MovecraftLocation offSet;
-    private final Craft craft;
+    private Craft craft;
 
     /**
      * Creates a new TrackedLocation instance which tracks a location about a craft's midpoint.
@@ -15,9 +16,7 @@ public class TrackedLocation {
      *                 location to the craft's central hitbox.
      */
     public TrackedLocation(@NotNull Craft craft, @NotNull MovecraftLocation location) {
-        this.craft = craft;
-        MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
-        offSet = location.subtract(midPoint);
+        this.reset(craft, location);
     }
 
     /**
@@ -44,4 +43,26 @@ public class TrackedLocation {
     public MovecraftLocation getOffSet() {
         return offSet;
     }
+
+    /**
+     * NEVER USE THIS UNLESS ABSOLUTELY NECESSARY
+     * @param craft
+     * @param location
+     */
+    public void reset(@NotNull Craft craft, @NotNull MovecraftLocation location) {
+        if (this.craft != null) {
+            if (!(
+                    // From parent to subcraft
+                    (craft instanceof SubCraft subCraft && subCraft.getParent() == this.craft)
+                    // From subcraft back to parent
+                    || (this.craft instanceof SubCraft subCraft2 && subCraft2.getParent() == craft)
+                )) {
+                throw new IllegalStateException("Only ever call this when transferring from or to subcraft!");
+            }
+        }
+        this.craft = craft;
+        MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
+        offSet = location.subtract(midPoint);
+    }
+
 }

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -24,10 +24,13 @@ public class TrackedLocation {
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
     public void rotate(MovecraftRotation rotation, MovecraftLocation origin) {
+        // TODO: SOMEHOW "absolute" and "origin" can end up to be the same thing?! WTF?!
         MovecraftLocation absolute = this.getAbsoluteLocation();
+        System.out.println("Absolute: " + absolute.toString());
         MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
 
         MovecraftLocation newAbsolute = origin.add(vector);
+        System.out.println("New absolute: " + newAbsolute.toString());
         // Ugly hack, but necessary
         Craft actualCraft = this.craft;
         this.craft = null;
@@ -72,6 +75,8 @@ public class TrackedLocation {
         }
         this.craft = craft;
         MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
+        System.out.println("Location: " + location.toString());
+        System.out.println("Midpoint: " + midPoint.toString());
         offSet = location.subtract(midPoint);
     }
 

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -1,22 +1,37 @@
 package net.countercraft.movecraft;
 
 import net.countercraft.movecraft.craft.Craft;
-import net.countercraft.movecraft.craft.SubCraft;
 import net.countercraft.movecraft.util.MathUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class TrackedLocation {
-    private MovecraftLocation offSet;
-    private Craft craft;
+
+    private int x;
+    private int y;
+    private int z;
 
     /**
      * Creates a new TrackedLocation instance which tracks a location about a craft's midpoint.
-     * @param craft The craft that's that tied to the location.
      * @param location The absolute position to track. This location will be stored as a relative
      *                 location to the craft's central hitbox.
      */
+    public TrackedLocation(@NotNull MovecraftLocation location) {
+        reinit(location);
+    }
+
+    @Deprecated(forRemoval = true)
     public TrackedLocation(@NotNull Craft craft, @NotNull MovecraftLocation location) {
-        this.reset(craft, location);
+        this(location);
+    }
+
+    protected void reinit(@NotNull MovecraftLocation location) {
+        reinit(location.getX(), location.getY(), location.getZ());
+    }
+
+    protected void reinit(final int x, final int y, final int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     /**
@@ -28,13 +43,25 @@ public class TrackedLocation {
         MovecraftLocation absolute = this.getAbsoluteLocation();
         System.out.println("Absolute: " + absolute.toString());
         MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
+        //MovecraftLocation vector = absolute.subtract(origin);
+        //int x = rotation == MovecraftRotation.ANTICLOCKWISE ? vector.getZ() : -vector.getZ();
+        //int z = rotation == MovecraftRotation.ANTICLOCKWISE ? -vector.getX() : vector.getX();
+        //vector = new MovecraftLocation(x, vector.getY(), z);
 
         MovecraftLocation newAbsolute = origin.add(vector);
         System.out.println("New absolute: " + newAbsolute.toString());
         // Ugly hack, but necessary
-        MovecraftLocation craftMidPoint = this.craft.getHitBox().getMidPoint();
-        this.offSet = newAbsolute.subtract(craftMidPoint);
+        //MovecraftLocation craftMidPoint = this.craft.getHitBox().getMidPoint();
+        //this.offSet = newAbsolute.subtract(craftMidPoint);
+        reinit(newAbsolute);
+
         System.out.println("New absolute after recalculating: " + this.getAbsoluteLocation().toString());
+    }
+
+    public void translate(final int dx, final int dy, final int dz) {
+        this.x += dx;
+        this.y += dy;
+        this.z += dz;
     }
 
     /**
@@ -42,16 +69,7 @@ public class TrackedLocation {
      * @return Returns the absolute location instead of a vector.
      */
     public MovecraftLocation getAbsoluteLocation() {
-        MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
-        return offSet.add(midPoint);
-    }
-
-    /**
-     * Gets the stored location as a position vector relative to the midpoint.
-     * @return Returns the absolute location instead of a vector.
-     */
-    public MovecraftLocation getOffSet() {
-        return offSet;
+        return new MovecraftLocation(this.x, this. y, this.z);
     }
 
     /**
@@ -60,7 +78,7 @@ public class TrackedLocation {
      * @param location
      */
     public void reset(@NotNull Craft craft, @NotNull MovecraftLocation location) {
-        if (craft == this.craft) {
+        /*if (craft == this.craft) {
             return;
         }
         if (this.craft != null) {
@@ -77,11 +95,8 @@ public class TrackedLocation {
         MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
         System.out.println("Location: " + location.toString());
         System.out.println("Midpoint: " + midPoint.toString());
-        offSet = location.subtract(midPoint);
-    }
-
-    public void reset(@NotNull MovecraftLocation location) {
-        this.reset(this.craft, location);
+        offSet = location.subtract(midPoint);*/
+        reinit(location);
     }
 
 }

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -39,23 +39,11 @@ public class TrackedLocation {
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
     public void rotate(MovecraftRotation rotation, MovecraftLocation origin) {
-        // TODO: SOMEHOW "absolute" and "origin" can end up to be the same thing?! WTF?!
         MovecraftLocation absolute = this.getAbsoluteLocation();
-        System.out.println("Absolute: " + absolute.toString());
         MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
-        //MovecraftLocation vector = absolute.subtract(origin);
-        //int x = rotation == MovecraftRotation.ANTICLOCKWISE ? vector.getZ() : -vector.getZ();
-        //int z = rotation == MovecraftRotation.ANTICLOCKWISE ? -vector.getX() : vector.getX();
-        //vector = new MovecraftLocation(x, vector.getY(), z);
 
         MovecraftLocation newAbsolute = origin.add(vector);
-        System.out.println("New absolute: " + newAbsolute.toString());
-        // Ugly hack, but necessary
-        //MovecraftLocation craftMidPoint = this.craft.getHitBox().getMidPoint();
-        //this.offSet = newAbsolute.subtract(craftMidPoint);
         reinit(newAbsolute);
-
-        System.out.println("New absolute after recalculating: " + this.getAbsoluteLocation().toString());
     }
 
     public void translate(final int dx, final int dy, final int dz) {
@@ -77,25 +65,12 @@ public class TrackedLocation {
      * @param craft
      * @param location
      */
+    @Deprecated(forRemoval = true)
     public void reset(@NotNull Craft craft, @NotNull MovecraftLocation location) {
-        /*if (craft == this.craft) {
-            return;
-        }
-        if (this.craft != null) {
-            if (!(
-                    // From parent to subcraft
-                    (craft instanceof SubCraft subCraft && subCraft.getParent() == this.craft)
-                    // From subcraft back to parent
-                    || (this.craft instanceof SubCraft subCraft2 && subCraft2.getParent() == craft)
-                )) {
-                throw new IllegalStateException("Only ever call this when transferring from or to subcraft!");
-            }
-        }
-        this.craft = craft;
-        MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
-        System.out.println("Location: " + location.toString());
-        System.out.println("Midpoint: " + midPoint.toString());
-        offSet = location.subtract(midPoint);*/
+        reset(location);
+    }
+
+    public void reset(@NotNull MovecraftLocation location) {
         reinit(location);
     }
 

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -32,9 +32,9 @@ public class TrackedLocation {
         MovecraftLocation newAbsolute = origin.add(vector);
         System.out.println("New absolute: " + newAbsolute.toString());
         // Ugly hack, but necessary
-        Craft actualCraft = this.craft;
-        this.craft = null;
-        reset(actualCraft, newAbsolute);
+        MovecraftLocation craftMidPoint = this.craft.getHitBox().getMidPoint();
+        this.offSet = newAbsolute.subtract(craftMidPoint);
+        System.out.println("New absolute after recalculating: " + this.getAbsoluteLocation().toString());
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -27,8 +27,7 @@ public class TrackedLocation {
 
     protected void reinit(@NotNull MovecraftLocation location) {
         Craft craft = this.getCraft();
-        Craft.CraftOrigin origin = craft.getCraftOrigin();
-        this.vector = location.subtract(origin);
+        this.vector = location.subtract(craft.getCraftOrigin());
     }
 
     /**
@@ -51,7 +50,7 @@ public class TrackedLocation {
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
     public void rotate(MovecraftRotation rotation) {
-        this.vector = MathUtils.rotateVec(rotation, new MovecraftLocation(this.dx, this.dy, this.dz));
+        this.vector = MathUtils.rotateVec(rotation, this.vector);
     }
 
     /**
@@ -60,9 +59,7 @@ public class TrackedLocation {
      */
     public MovecraftLocation getAbsoluteLocation() {
         Craft craft = this.getCraft();
-        Craft.CraftOrigin origin = craft.getCraftOrigin();
-
-        return this.vector.add(origin);
+        return this.vector.add(craft.getCraftOrigin());
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -41,11 +41,11 @@ public class TrackedLocation {
      * Rotates the stored location.
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
-    public void rotate(MovecraftRotation rotation, MovecraftLocation origin) {
+    public void rotate(MovecraftRotation rotation, MovecraftLocation rotationPoint) {
         MovecraftLocation absolute = this.getAbsoluteLocation();
-        MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
+        MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(rotationPoint));
 
-        MovecraftLocation newAbsolute = origin.add(vector);
+        MovecraftLocation newAbsolute = rotationPoint.add(vector);
         reinit(newAbsolute);
     }
 

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -58,8 +58,8 @@ public class TrackedLocation {
         Craft.CraftOrigin origin = craft.getCraftOrigin();
 
         int x = origin.getX() + this.dx;
-        int y = origin.getX() + this.dy;
-        int z = origin.getX() + this.dz;
+        int y = origin.getY() + this.dy;
+        int z = origin.getZ() + this.dz;
 
         return new MovecraftLocation(x, y, z);
     }

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -8,9 +8,7 @@ import java.lang.ref.WeakReference;
 
 public class TrackedLocation {
 
-    private int dx;
-    private int dy;
-    private int dz;
+    private MovecraftLocation vector;
 
     private WeakReference<Craft> craft;
 
@@ -26,15 +24,9 @@ public class TrackedLocation {
     }
 
     protected void reinit(@NotNull MovecraftLocation location) {
-        reinit(location.getX(), location.getY(), location.getZ());
-    }
-
-    protected void reinit(final int x, final int y, final int z) {
         Craft craft = this.getCraft();
         Craft.CraftOrigin origin = craft.getCraftOrigin();
-        this.dx = x - origin.getX();
-        this.dy = y - origin.getY();
-        this.dz = z - origin.getZ();
+        this.vector = location.subtract(origin);
     }
 
     /**
@@ -42,11 +34,7 @@ public class TrackedLocation {
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
     public void rotate(MovecraftRotation rotation) {
-        MovecraftLocation newVector = MathUtils.rotateVec(rotation, new MovecraftLocation(this.dx, this.dy, this.dz));
-
-        this.dx = newVector.getX();
-        this.dy = newVector.getY();
-        this.dz = newVector.getZ();
+        this.vector = MathUtils.rotateVec(rotation, new MovecraftLocation(this.dx, this.dy, this.dz));
     }
 
     /**
@@ -57,11 +45,7 @@ public class TrackedLocation {
         Craft craft = this.getCraft();
         Craft.CraftOrigin origin = craft.getCraftOrigin();
 
-        int x = origin.getX() + this.dx;
-        int y = origin.getY() + this.dy;
-        int z = origin.getZ() + this.dz;
-
-        return new MovecraftLocation(x, y, z);
+        return this.vector.add(origin);
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -28,7 +28,7 @@ public class TrackedLocation {
         MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
 
         MovecraftLocation newAbsolute = origin.add(vector);
-        offSet = offSet.add(newAbsolute.subtract(absolute));
+        reset(this.craft, newAbsolute);
     }
 
     /**
@@ -70,6 +70,10 @@ public class TrackedLocation {
         this.craft = craft;
         MovecraftLocation midPoint = craft.getHitBox().getMidPoint();
         offSet = location.subtract(midPoint);
+    }
+
+    public void reset(@NotNull MovecraftLocation location) {
+        this.reset(this.craft, location);
     }
 
 }

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -50,6 +50,9 @@ public class TrackedLocation {
      * @param location
      */
     public void reset(@NotNull Craft craft, @NotNull MovecraftLocation location) {
+        if (craft == this.craft) {
+            return;
+        }
         if (this.craft != null) {
             if (!(
                     // From parent to subcraft

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -28,7 +28,10 @@ public class TrackedLocation {
         MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
 
         MovecraftLocation newAbsolute = origin.add(vector);
-        reset(this.craft, newAbsolute);
+        // Ugly hack, but necessary
+        Craft actualCraft = this.craft;
+        this.craft = null;
+        reset(actualCraft, newAbsolute);
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -24,7 +24,11 @@ public class TrackedLocation {
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
     public void rotate(MovecraftRotation rotation, MovecraftLocation origin) {
-        offSet = MathUtils.rotateVec(rotation, getAbsoluteLocation().subtract(origin));
+        MovecraftLocation absolute = this.getAbsoluteLocation();
+        MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(origin));
+
+        MovecraftLocation newAbsolute = origin.add(vector);
+        offSet = offSet.add(newAbsolute.subtract(absolute));
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
+++ b/api/src/main/java/net/countercraft/movecraft/TrackedLocation.java
@@ -41,12 +41,12 @@ public class TrackedLocation {
      * Rotates the stored location.
      * @param rotation A clockwise or counter-clockwise direction to rotate.
      */
-    public void rotate(MovecraftRotation rotation, MovecraftLocation rotationPoint) {
-        MovecraftLocation absolute = this.getAbsoluteLocation();
-        MovecraftLocation vector = MathUtils.rotateVec(rotation, absolute.subtract(rotationPoint));
+    public void rotate(MovecraftRotation rotation) {
+        MovecraftLocation newVector = MathUtils.rotateVec(rotation, new MovecraftLocation(this.dx, this.dy, this.dz));
 
-        MovecraftLocation newAbsolute = rotationPoint.add(vector);
-        reinit(newAbsolute);
+        this.dx = newVector.getX();
+        this.dy = newVector.getY();
+        this.dz = newVector.getZ();
     }
 
     /**

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -53,9 +53,7 @@ public interface Craft {
     CraftDataTagKey<Counter<RequiredBlockEntry>> MOVEBLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "moveblocks"), craft -> new Counter<>());
     CraftDataTagKey<Integer> NON_NEGLIGIBLE_BLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "non-negligible-blocks"), Craft::getOrigBlockCount);
     CraftDataTagKey<Integer> NON_NEGLIGIBLE_SOLID_BLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "non-negligible-solid-blocks"), Craft::getOrigBlockCount);
-    CraftDataTagKey<MovecraftLocation> CRAFT_ORIGIN = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "craft-origin"), craft -> {
-        return craft.getHitBox().getMidPoint();
-    });
+    CraftDataTagKey<MovecraftLocation> CRAFT_ORIGIN = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "craft-origin"), craft -> craft.getHitBox().getMidPoint());
 
     // Java disallows private or protected fields in interfaces, this is a workaround
     class Hidden {

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -40,9 +40,7 @@ import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
-import org.joml.Vector3i;
 
-import javax.naming.Name;
 import java.util.*;
 
 public interface Craft {

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -63,60 +63,25 @@ public interface Craft {
 
     public class CraftOrigin {
 
-        private int x;
-        private int y;
-        private int z;
+        private MovecraftLocation location;
 
         public CraftOrigin(final @NotNull Craft craft) {
-
+            this.location = craft.getHitbox().getMidPoint();
         }
 
         public void translate(int dx, int dy, int dz) {
-            this.x += dx;
-            this.y += dy;
-            this.z += dz;
+            this.location = this.location.translate(dx, dy, dz);
         }
 
         public void rotate(final MovecraftLocation rotationPoint, final MovecraftRotation rotation) {
             MovecraftLocation oldAbsolute = this.getLocation();
             MovecraftLocation vector = oldAbsolute.subtract(rotationPoint);
             MovecraftLocation vectorRotated = MathUtils.rotateVec(rotation, vector);
-            MovecraftLocation newAbsolute = rotationPoint.add(vectorRotated);
-            this.copyValues(newAbsolute);
-        }
-
-        public void copyValues(final MovecraftLocation location) {
-            this.x = location.getX();
-            this.y = location.getY();
-            this.z = location.getZ();
-        }
-
-        public int getX() {
-            return x;
-        }
-
-        public void setX(int x) {
-            this.x = x;
-        }
-
-        public int getY() {
-            return y;
-        }
-
-        public void setY(int y) {
-            this.y = y;
-        }
-
-        public int getZ() {
-            return z;
-        }
-
-        public void setZ(int z) {
-            this.z = z;
+            this.location = rotationPoint.add(vectorRotated);
         }
 
         public MovecraftLocation getLocation() {
-            return new MovecraftLocation(x, y, z);
+            return this.location;
         }
 
     }

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -53,37 +53,14 @@ public interface Craft {
     CraftDataTagKey<Counter<RequiredBlockEntry>> MOVEBLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "moveblocks"), craft -> new Counter<>());
     CraftDataTagKey<Integer> NON_NEGLIGIBLE_BLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "non-negligible-blocks"), Craft::getOrigBlockCount);
     CraftDataTagKey<Integer> NON_NEGLIGIBLE_SOLID_BLOCKS = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "non-negligible-solid-blocks"), Craft::getOrigBlockCount);
-    CraftDataTagKey<CraftOrigin> CRAFT_ORIGIN = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "craft-origin"), CraftOrigin::new);
+    CraftDataTagKey<MovecraftLocation> CRAFT_ORIGIN = CraftDataTagRegistry.INSTANCE.registerTagKey(new NamespacedKey("movecraft", "craft-origin"), craft -> {
+        return craft.getHitBox().getMidPoint();
+    });
 
     // Java disallows private or protected fields in interfaces, this is a workaround
     class Hidden {
         // Concurrent so we don't have problems when accessing async (useful for addon plugins that want to do stuff async, for example NPC crafts with complex off-thread pathfinding)
         protected static final Map<UUID, Craft> uuidToCraft = Collections.synchronizedMap(new WeakHashMap<>());
-    }
-
-    public class CraftOrigin {
-
-        private MovecraftLocation location;
-
-        public CraftOrigin(final @NotNull Craft craft) {
-            this.location = craft.getHitbox().getMidPoint();
-        }
-
-        public void translate(int dx, int dy, int dz) {
-            this.location = this.location.translate(dx, dy, dz);
-        }
-
-        public void rotate(final MovecraftLocation rotationPoint, final MovecraftRotation rotation) {
-            MovecraftLocation oldAbsolute = this.getLocation();
-            MovecraftLocation vector = oldAbsolute.subtract(rotationPoint);
-            MovecraftLocation vectorRotated = MathUtils.rotateVec(rotation, vector);
-            this.location = rotationPoint.add(vectorRotated);
-        }
-
-        public MovecraftLocation getLocation() {
-            return this.location;
-        }
-
     }
 
     public static Craft getCraftByUUID(final UUID uuid) {
@@ -323,7 +300,7 @@ public interface Craft {
 
     Map<NamespacedKey, Set<TrackedLocation>> getTrackedLocations();
 
-    public default CraftOrigin getCraftOrigin() {
+    public default MovecraftLocation getCraftOrigin() {
         return this.getDataTag(CRAFT_ORIGIN);
     }
 }


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
Adds proper support for subcrafts to tracked locations. Transfers them to the subcraft and back to the parent on release. The object stays the same so things that use the TrackedLocation can continue to use the same old object and that that updates accordingly.

Also fixes trackedlocations being wrongly rotated on subcrafts in general (the rotation code present does not rotate it correctly, it is necessary to recalculate the new absolute and to adjust the offset via that)

Also re-works trackedlocations so that they basically "move around" a cached value. This is necessary since the old approach used the craft's midpoint as reference location. But since that midpoint can and will change (for example via subcrafts or gradual destruction or launching a torpedo for example) it cant be used as a reference location as that will also move the effective location since the internally stored vector always stays the same

### Checklist
- [x] Tested 
