### PR TITLE
[Fix] Correct piston merge related logic

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -52,6 +52,7 @@ import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.material.Attachable;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import java.util.List;
 
 public class BlockListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -126,15 +126,15 @@ public class BlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPistonExtendEvent(@NotNull BlockPistonExtendEvent e) {
-        onPistonEvent(e);
+        onPistonEvent(e, e.getBlocks());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPistonRetractEvent(@NotNull BlockPistonRetractEvent e) {
-        onPistonEvent(e);
+        onPistonEvent(e, e.getBlocks());
     }
 
-    public void onPistonEvent(@NotNull BlockPistonEvent e) {
+    public void onPistonEvent(@NotNull BlockPistonEvent e, final @NotNull List<Block> affectedBlocks) {
         Block block = e.getBlock();
         Location location = block.getLocation();
         MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(location);
@@ -143,15 +143,13 @@ public class BlockListener implements Listener {
                 continue;
 
            if (!craft.isNotProcessing())
-               e.setCancelled(true); // prevent pistons on cruising crafts
-           if (!(e instanceof BlockPistonExtendEvent))
-               return;
-            // merge piston extensions to craft
-           if (craft.getType().getBoolProperty(CraftType.MERGE_PISTON_EXTENSIONS))
+               e.setCancelled(true); // prevent pistons on cruising crafts           
+            // merge piston extensions to craft if the property is true
+           if (!craft.getType().getBoolProperty(CraftType.MERGE_PISTON_EXTENSIONS))
                 continue;
 
            BitmapHitBox hitBox = new BitmapHitBox();
-           for (Block b : ((BlockPistonExtendEvent) e).getBlocks()) {
+           for (Block b : affectedBlocks) {
                Vector dir = e.getDirection().getDirection();
                hitBox.add(new MovecraftLocation(b.getX() + dir.getBlockX(), b.getY() + dir.getBlockY(), b.getZ() + dir.getBlockZ()));
            }


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
Fixes the inverted logic in the event handler.
Since both retract and extend calls that method, it should do something for either case, so remove the instanceof check for the Extend event and instead use a list.

### Checklist
- [x] Tested
