### PR TITLE
Reuse already calculated tags

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
@@ -130,25 +130,12 @@ public class StatusManager extends BukkitRunnable implements Listener {
 
         boolean sinking = false;
         boolean disabled = false;
-        Counter<Material> materials = craft.getDataTag(Craft.MATERIALS);
         int nonNegligibleBlocks = craft.getDataTag(Craft.NON_NEGLIGIBLE_BLOCKS);
         int nonNegligibleSolidBlocks = craft.getDataTag(Craft.NON_NEGLIGIBLE_SOLID_BLOCKS);
 
         // Build up counters of the fly and move blocks
-        Counter<RequiredBlockEntry> flyBlocks = new Counter<>();
-        flyBlocks.putAll(craft.getType().getRequiredBlockProperty(CraftType.FLY_BLOCKS));
-        Counter<RequiredBlockEntry> moveBlocks = new Counter<>();
-        moveBlocks.putAll(craft.getType().getRequiredBlockProperty(CraftType.MOVE_BLOCKS));
-        for (Material m : materials.getKeySet()) {
-            for (RequiredBlockEntry entry : flyBlocks.getKeySet()) {
-                if(entry.contains(m))
-                    flyBlocks.add(entry, materials.get(m));
-            }
-            for (RequiredBlockEntry entry : moveBlocks.getKeySet()) {
-                if(entry.contains(m))
-                    moveBlocks.add(entry, materials.get(m));
-            }
-        }
+        Counter<RequiredBlockEntry> flyBlocks = craft.getDataTag(Craft.FLYBLOCKS);
+        Counter<RequiredBlockEntry> moveBlocks = craft.getDataTag(Craft.MOVEBLOCKS);
 
         // now see if any of the resulting percentages are below the threshold specified in sinkPercent
         double sinkPercent = craft.getType().getDoubleProperty(CraftType.SINK_PERCENT) / 100.0;


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes
We already calculated Flyblocks and Moveblocks counters in the StatusManager's supplier, let's reuse their calculation (which was saved in the craft's data tags FLYBLOCKS and MOVEBLOCKS) instead of recalculating it from the MATERIALS tag.

### Checklist
- [ ] Tested
