### PR TITLE
Api/post sink

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -82,7 +82,7 @@ public abstract class BaseCraft implements Craft {
     private Map<NamespacedKey, Set<TrackedLocation>> trackedLocations = new HashMap<>();
 
     @NotNull
-    private final CraftDataTagContainer dataTagContainer;
+    protected CraftDataTagContainer dataTagContainer;
 
     private final UUID uuid;
 
@@ -584,4 +584,12 @@ public abstract class BaseCraft implements Craft {
 
     @Override
     public Map<NamespacedKey, Set<TrackedLocation>> getTrackedLocations() {return trackedLocations;}
+
+    /**
+     * @return copy of dataTagContainer, changes to the returned CraftDataTagContainer won't be reflected to the actual craft
+     */
+    @Override
+    public @NotNull CraftDataTagContainer getDataTagContainer() {
+        return dataTagContainer.copy(this);
+    }
 }

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -84,9 +84,26 @@ public abstract class BaseCraft implements Craft {
     @NotNull
     private final CraftDataTagContainer dataTagContainer;
 
-    private final UUID uuid = UUID.randomUUID();
+    private final UUID uuid;
+
+    public BaseCraft(@NotNull CraftType type, @NotNull World world, UUID uuid) {
+        this.uuid = uuid;
+        Hidden.uuidToCraft.put(uuid, this);
+        this.type = type;
+        this.w = world;
+        hitBox = new SetHitBox();
+        collapsedHitBox = new SetHitBox();
+        fluidLocations = new SetHitBox();
+        lastCruiseUpdate = System.currentTimeMillis();
+        cruising = false;
+        disabled = false;
+        origPilotTime = System.currentTimeMillis();
+        audience = Audience.empty();
+        dataTagContainer = new CraftDataTagContainer();
+    }
 
     public BaseCraft(@NotNull CraftType type, @NotNull World world) {
+        this.uuid = UUID.randomUUID();
         Hidden.uuidToCraft.put(uuid, this);
         this.type = type;
         this.w = world;

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/BaseCraft.java
@@ -103,19 +103,7 @@ public abstract class BaseCraft implements Craft {
     }
 
     public BaseCraft(@NotNull CraftType type, @NotNull World world) {
-        this.uuid = UUID.randomUUID();
-        Hidden.uuidToCraft.put(uuid, this);
-        this.type = type;
-        this.w = world;
-        hitBox = new SetHitBox();
-        collapsedHitBox = new SetHitBox();
-        fluidLocations = new SetHitBox();
-        lastCruiseUpdate = System.currentTimeMillis();
-        cruising = false;
-        disabled = false;
-        origPilotTime = System.currentTimeMillis();
-        audience = Audience.empty();
-        dataTagContainer = new CraftDataTagContainer();
+        this(type, world, UUID.randomUUID());
     }
 
 

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/CraftManager.java
@@ -20,6 +20,7 @@ package net.countercraft.movecraft.craft;
 import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.type.CraftType;
+import net.countercraft.movecraft.events.CraftPostSinkEvent;
 import net.countercraft.movecraft.events.CraftReleaseEvent;
 import net.countercraft.movecraft.events.CraftSinkEvent;
 import net.countercraft.movecraft.events.TypesReloadedEvent;
@@ -202,7 +203,10 @@ public class CraftManager implements Iterable<Craft>{
         if (craft instanceof PlayerCraft)
             playerCrafts.remove(((PlayerCraft) craft).getPilot());
 
-        crafts.add(new SinkingCraftImpl(craft));
+        SinkingCraft sinkingCraft = new SinkingCraftImpl(craft);
+        CraftPostSinkEvent postEvent = new CraftPostSinkEvent(craft, sinkingCraft);
+        Bukkit.getServer().getPluginManager().callEvent(postEvent);
+        crafts.add(sinkingCraft);
     }
 
     public void release(@NotNull Craft craft, @NotNull CraftReleaseEvent.Reason reason, boolean force) {

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/SinkingCraftImpl.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/SinkingCraftImpl.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class SinkingCraftImpl extends BaseCraft implements SinkingCraft {
     public SinkingCraftImpl(@NotNull Craft original) {
-        super(original.getType(), original.getWorld());
+        super(original.getType(), original.getWorld(), original.getUUID());
         hitBox = original.getHitBox();
         collapsedHitBox.addAll(original.getCollapsedHitBox());
         fluidLocations = original.getFluidLocations();

--- a/Movecraft/src/main/java/net/countercraft/movecraft/craft/SinkingCraftImpl.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/craft/SinkingCraftImpl.java
@@ -8,6 +8,7 @@ public class SinkingCraftImpl extends BaseCraft implements SinkingCraft {
         hitBox = original.getHitBox();
         collapsedHitBox.addAll(original.getCollapsedHitBox());
         fluidLocations = original.getFluidLocations();
+        dataTagContainer = original.getDataTagContainer();
         setOrigBlockCount(original.getOrigBlockCount());
         setCruiseDirection(original.getCruiseDirection());
         setLastTranslation(original.getLastTranslation());

--- a/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -21,6 +21,7 @@ import net.countercraft.movecraft.CruiseDirection;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.MovecraftRotation;
 import net.countercraft.movecraft.TrackedLocation;
+import net.countercraft.movecraft.craft.datatag.CraftDataTagContainer;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagKey;
 import net.countercraft.movecraft.craft.datatag.CraftDataTagRegistry;
 import net.countercraft.movecraft.craft.type.CraftType;
@@ -274,6 +275,8 @@ public interface Craft {
     Audience getAudience();
 
     void setAudience(Audience audience);
+
+    @NotNull CraftDataTagContainer getDataTagContainer();
 
     <T> void setDataTag(@NotNull final CraftDataTagKey<T> tagKey, final T data);
 

--- a/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
+++ b/api/src/main/java/net/countercraft/movecraft/craft/datatag/CraftDataTagContainer.java
@@ -4,6 +4,8 @@ import net.countercraft.movecraft.craft.Craft;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -13,6 +15,10 @@ public class CraftDataTagContainer {
 
     public CraftDataTagContainer(){
         backing = new ConcurrentHashMap<>();
+    }
+
+    private CraftDataTagContainer(Map<@NotNull CraftDataTagKey<?>, @Nullable Object> map) {
+        backing = new ConcurrentHashMap<>(map);
     }
 
     /**
@@ -52,5 +58,16 @@ public class CraftDataTagContainer {
         }
 
         backing.put(tagKey, value);
+    }
+
+    public CraftDataTagContainer copy(Craft craft) {
+        HashMap<CraftDataTagKey<?>, Object> clone = new HashMap<>();
+        for (var entry : backing.entrySet()) {
+            CraftDataTagKey<?> key = entry.getKey();
+            Object value = this.get(craft, key);
+            clone.put(key, value);
+        }
+
+        return new CraftDataTagContainer(clone);
     }
 }

--- a/api/src/main/java/net/countercraft/movecraft/events/CraftPostSinkEvent.java
+++ b/api/src/main/java/net/countercraft/movecraft/events/CraftPostSinkEvent.java
@@ -1,0 +1,30 @@
+package net.countercraft.movecraft.events;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.SinkingCraft;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class CraftPostSinkEvent extends CraftEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final SinkingCraft sinkingCraft;
+
+    public CraftPostSinkEvent(@NotNull Craft craft, SinkingCraft sinkingCraft) {
+        super(craft);
+        this.sinkingCraft = sinkingCraft;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    public SinkingCraft getSinkingCraft() {
+        return sinkingCraft;
+    }
+}


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes

When a craft is sunk, the reference to the old craft is delete and a new one is created, this creates problems in plugins that store Crafts in HashMap or in general want to obtain the new sinked craft, a new event has been added to fix the issue and SinkingCraftImpl now has the same uuid as the sinked craft.