### PR TITLE
Fix build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@
 
 plugins {
     id("buildlogic.java-conventions")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.10" apply false
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixes the build process on the 1.21.x module being broken after commit #8919cb0

Gradle was outdated and so was the paperweight plugin