### PR TITLE
Fix moveblocks

### DIFF
--- a/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
+++ b/Movecraft/src/main/java/net/countercraft/movecraft/features/status/StatusManager.java
@@ -67,9 +67,7 @@ public class StatusManager extends BukkitRunnable implements Listener {
 
         @Override
         public @NotNull Effect get() {
-            Counter<Material> materials = craft.getDataTag(Craft.MATERIALS);
-            materials.clear();
-
+            Counter<Material> materials = new Counter<>();
             int nonNegligibleBlocks = 0;
             int nonNegligibleSolidBlocks = 0;
             double fuel = 0;
@@ -95,10 +93,8 @@ public class StatusManager extends BukkitRunnable implements Listener {
                 }
             }
 
-            Counter<RequiredBlockEntry> flyblocks = craft.getDataTag(Craft.FLYBLOCKS);
-            flyblocks.clear();
-            Counter<RequiredBlockEntry> moveblocks = craft.getDataTag(Craft.MOVEBLOCKS);
-            moveblocks.clear();
+            Counter<RequiredBlockEntry> flyblocks = new Counter<>();
+            Counter<RequiredBlockEntry> moveblocks = new Counter<>();
 
             // Pre-fill the moveblocks counter to avoid ignoring moveblocks
             for(RequiredBlockEntry entry : craft.getType().getRequiredBlockProperty(CraftType.MOVE_BLOCKS)) {
@@ -119,9 +115,10 @@ public class StatusManager extends BukkitRunnable implements Listener {
                 }
             }
 
-            // Primitive type tags => Re-apply those
-            // RE-applying is not necessary for object tags as we manipulate the object itself
             craft.setDataTag(Craft.FUEL, fuel);
+            craft.setDataTag(Craft.MATERIALS, materials);
+            craft.setDataTag(Craft.FLYBLOCKS, flyblocks);
+            craft.setDataTag(Craft.MOVEBLOCKS, moveblocks);
             craft.setDataTag(Craft.NON_NEGLIGIBLE_BLOCKS, nonNegligibleBlocks);
             craft.setDataTag(Craft.NON_NEGLIGIBLE_SOLID_BLOCKS, nonNegligibleSolidBlocks);
             craft.setDataTag(LAST_STATUS_CHECK, System.currentTimeMillis());


### PR DESCRIPTION
### Describe in detail what your pull request accomplishes
If a craft has moveblocks defined and there are no moveblocks placed (or all were destroyed) on the craft, the craft will not disable.

Also changed some datatags here to not create a new object every single time and instead re-used the existing one.

### Checklist
- [x] Tested
